### PR TITLE
docs: Azores Hub SDD & phased migration plan

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -1,0 +1,178 @@
+# Azores Hub — Migration Plan & Software Design Document (SDD)
+
+> **Status:** DRAFT — awaiting explicit approval before any implementation begins.
+> **Author:** Architecture (Cursor agent)
+> **Target repo:** `sao-miguel-hub` (first instance of the multi-island **Azores Hub** platform)
+> **Source material:** legacy `SaoMiguelBus` (mobile), `SaoMiguelBus-api` (Django/DRF), `SaoMiguelBus-webapp` (vanilla-JS PWA)
+
+This document is the **executive index** for the migration. The detailed design lives in the [`SDD/`](./SDD) directory. Nothing here authorizes writing application code — it defines the architecture and the phased plan we will execute **after sign-off**.
+
+---
+
+## 1. TL;DR
+
+We are turning a single-purpose São Miguel bus-schedule app into **Azores Hub**: a white-labelable "island guide + community hub" that ships from one Expo (React Native + Web) codebase against a modernized, multi-tenant Django backend built on the `djast` boilerplate.
+
+The legacy stack is functional but fragile:
+
+- **Backend:** Django 3.0.14 (EOL), DRF function-views, **no relational schedule model** — a "schedule" is one `Route` row whose `stops` column is a *stringified Python dict* (`{'Stop A': '08h30', ...}`). Tracking is a single flat `Stat` table. Premium is a manual email allow-list. No `Island`/tenant concept.
+- **Frontend:** a ~2,400-line `index.html` + ~5k lines of global-scoped JS, Tailwind via CDN, no build step, API base URL hardcoded, triple analytics stack (GA + Umami + `/api/v1/stat`).
+- **Mobile:** parallel native-Android (Kotlin) and partial Flutter ports, each with their own embedded copy of the schedule.
+
+Azores Hub consolidates all of this into **two repos** (one backend, one Expo app), introduces an `Island` tenant root that every domain model hangs off, a normalized transit schema, a unified `AnalyticsEvent` pipeline with GDPR-grade governance, and a freemium monetization layer.
+
+See [`SDD/00-overview.md`](./SDD/00-overview.md) for the full vision and scope.
+
+---
+
+## 2. Guiding principles
+
+1. **Tenant-first.** Every domain row is scoped to an `Island`. The query layer filters by the active island by default; cloning a new island is config + data, not code.
+2. **One codebase, three targets.** Expo Router drives Android, iOS, and Web from a single source. Branding/theming is data, not forks.
+3. **Privacy by design.** No raw IPs or stable user IDs in analytics without consent. Pseudonymized session hashing, automated retention, DSAR-ready schema.
+4. **Backward-compatible cutover.** Legacy `/api/v1` and `/api/v2` contracts are preserved behind a compatibility shim so existing Play Store / web clients keep working during migration.
+5. **Modular monolith, not microservices.** Each feature (Transit, News, Earthquakes, Marketplace, Trails, Traffic, Events) is a Django app + an Expo feature module sharing common tenant/analytics/consent infra.
+6. **Don't lose history.** All data accumulated since 2020 (routes, stats, ads, subscriptions, likes) is migrated, normalized, and pseudonymized in flight.
+
+---
+
+## 3. Target architecture at a glance
+
+```
+                         ┌───────────────────────────────────────────┐
+                         │            Expo app (RN + Web)              │
+                         │  one codebase · Android · iOS · Web         │
+                         │  theme/config injected per ISLAND_KEY       │
+                         └───────────────┬─────────────────────────────┘
+                                         │ HTTPS / JSON (X-Island header)
+                                         ▼
+        ┌────────────────────────────────────────────────────────────────┐
+        │                  djast Django backend (modular monolith)         │
+        │  tenancy · auth · analytics · consent · billing                  │
+        │  ┌────────┬────────┬───────────┬─────────┬────────┬───────────┐  │
+        │  │transit │ news   │earthquakes│market   │trails  │ traffic   │  │
+        │  │        │        │           │place    │        │ events    │  │
+        │  └────────┴────────┴───────────┴─────────┴────────┴───────────┘  │
+        │  DRF ViewSets · PostgreSQL (tenant-scoped) · Celery + Redis      │
+        └───────┬───────────────────────────────────┬──────────────────────┘
+                │                                     │
+        ┌───────▼────────┐                   ┌────────▼─────────────────────┐
+        │ External feeds  │                   │ Monetization & infra          │
+        │ EMSC seismic    │                   │ Stripe / RevenueCat           │
+        │ dados.gov.pt    │                   │ AdMob / AdSense               │
+        │ RSS news        │                   │ Viator affiliate              │
+        │ Google Maps     │                   │ Object storage / CDN          │
+        └─────────────────┘                   └───────────────────────────────┘
+```
+
+Full detail: [`SDD/01-architecture.md`](./SDD/01-architecture.md).
+
+---
+
+## 4. SDD index
+
+| Doc | Contents |
+|-----|----------|
+| [`00-overview.md`](./SDD/00-overview.md) | Vision, scope, personas, glossary, success metrics |
+| [`01-architecture.md`](./SDD/01-architecture.md) | System architecture, tech stack, repo layout, `djast` config, environments |
+| [`02-multi-island-whitelabel.md`](./SDD/02-multi-island-whitelabel.md) | `Island`/`Hub` tenant root, request scoping, frontend theming config |
+| [`03-data-model.md`](./SDD/03-data-model.md) | Full target schema per module + legacy→new field mapping |
+| [`04-api-design.md`](./SDD/04-api-design.md) | REST conventions, versioning, auth, legacy compatibility shims |
+| [`05-data-migration.md`](./SDD/05-data-migration.md) | ETL strategy for 2020+ data, `stops`-dict parsing, dual-write cutover |
+| [`06-analytics-tracking.md`](./SDD/06-analytics-tracking.md) | `AnalyticsEvent` normalization, module-wide instrumentation |
+| [`07-gdpr-data-governance.md`](./SDD/07-gdpr-data-governance.md) | CMP, pseudonymization, retention jobs, DSAR runbook |
+| [`08-monetization-freemium.md`](./SDD/08-monetization-freemium.md) | Free/Premium tiers, Stripe + RevenueCat, ads, Pay-to-Promote |
+| [`09-modules.md`](./SDD/09-modules.md) | News, Earthquakes, Marketplace, Trails/Tourist, Traffic, Events, Viator |
+| [`10-frontend-architecture.md`](./SDD/10-frontend-architecture.md) | Expo Router layout, state, offline maps, CMP integration |
+| [`11-security-auth.md`](./SDD/11-security-auth.md) | Identity, secrets, abuse/crowdsourcing trust, threat model |
+| [`12-risks-open-questions.md`](./SDD/12-risks-open-questions.md) | Risks, assumptions, decisions needed before coding |
+
+---
+
+## 5. Phased migration plan
+
+Each phase has an **objective**, **scope**, **exit criteria**, and **dependencies**. Phases are sequenced so that nothing later is blocked, and so the legacy app keeps running throughout. Effort is described in terms of subsystems touched and risk — not calendar time.
+
+### Phase 0 — Foundations & sign-off (this document)
+
+- **Objective:** agree the architecture, schema, and governance model.
+- **Scope:** this SDD; provisioning the `sao-miguel-hub` repo; confirming `djast` capabilities; locking the external-API contracts (EMSC, dados.gov.pt, RSS sources).
+- **Exit criteria:** stakeholder approval of the SDD; open questions in [`12-risks-open-questions.md`](./SDD/12-risks-open-questions.md) resolved or accepted.
+
+### Phase 1 — Architecture, multi-island schema & migration strategy
+
+- **Objective:** stand up the new backend skeleton with the tenant root and a working data-migration path.
+- **Scope:**
+  - Bootstrap `djast` backend; configure PostgreSQL, Celery + Redis, settings per environment ([`01`](./SDD/01-architecture.md)).
+  - Implement the `Island`/`Hub` tenant root + request scoping middleware and `TenantScopedModel` base ([`02`](./SDD/02-multi-island-whitelabel.md)).
+  - Define the **normalized transit schema** (`Operator`, `Line`, `Stop`, `Trip`, `StopTime`, `Calendar`) plus `Ad`, `Info`, `Holiday`, `RouteFeedback` ([`03`](./SDD/03-data-model.md)).
+  - Build the **ETL** that parses legacy `Route.stops` stringified dicts, normalizes stop names via `cleaned_name`, and loads everything under `island=sao-miguel`. Dual-read validation against the legacy API ([`05`](./SDD/05-data-migration.md)).
+  - Define the **legacy compatibility shim** mapping new schema → old `/api/v1` + `/api/v2` response shapes so current clients don't break ([`04`](./SDD/04-api-design.md)).
+- **Exit criteria:** new backend serves São Miguel transit data through both the new API and the compat shim; migrated data byte-diff-validated against production `/api/v2/webapp/load`.
+- **Depends on:** Phase 0.
+
+### Phase 2 — GDPR/Analytics foundation, theming & Expo bootstrap
+
+- **Objective:** privacy-safe analytics spine and the cross-platform app shell.
+- **Scope:**
+  - `AnalyticsEvent` model + ingestion endpoint + client SDK contract; deprecate flat `Stat` (migrate historical `Stat` rows into `AnalyticsEvent`) ([`06`](./SDD/06-analytics-tracking.md)).
+  - Consent model, pseudonymized session hashing, Celery retention/anonymization tasks (14-month default), DSAR export/delete commands ([`07`](./SDD/07-gdpr-data-governance.md)).
+  - Expo Router app skeleton: tab navigation, global theme provider driven by `ISLAND_NAME` / `PRIMARY_COLOR` / `SECONDARY_COLOR` / logos, i18n port of the 8 existing locales, CMP consent flow on first launch ([`02`](./SDD/02-multi-island-whitelabel.md), [`10`](./SDD/10-frontend-architecture.md)).
+- **Exit criteria:** app boots on Android/iOS/Web with São Miguel branding; consent gate works; a sample event flows end-to-end into `AnalyticsEvent` only after consent; retention job verified on seeded data.
+- **Depends on:** Phase 1 (tenant root, backend skeleton).
+
+### Phase 3 — Core transit migration & external data integrations
+
+- **Objective:** feature-parity transit experience + the daily-utility data feeds.
+- **Scope:**
+  - Port transit search (origin→destination, day-type, step-by-step directions via Google Maps proxy) onto the new schema and Expo UI; favorites, likes/dislikes, offline schedule cache ([`09`](./SDD/09-modules.md)).
+  - **Trails:** Celery sync from `dados.gov.pt` open-data API → `Trail`/`TrailStage` models; offline map tiles + micro-climate weather ([`09`](./SDD/09-modules.md)).
+  - **Earthquakes:** EMSC-CSEM polling → `SeismicEvent`; crowdsourced "I felt it" reports ([`09`](./SDD/09-modules.md)).
+  - **News:** Celery RSS scraper/parser for Azorean journals → `NewsArticle` with source attribution ([`09`](./SDD/09-modules.md)).
+- **Exit criteria:** São Miguel users get transit + trails + earthquakes + news in the new app; feeds refresh on schedule; all instrumented through `AnalyticsEvent`.
+- **Depends on:** Phases 1–2.
+
+### Phase 4 — Community & crowdsourced modules
+
+- **Objective:** the "hub/community" surface area.
+- **Scope:**
+  - **Marketplace:** tradesperson directory (`ServiceProvider`, `ServiceCategory`, `Review`), free listings, moderation ([`09`](./SDD/09-modules.md)).
+  - **Events:** community submission + moderation (`CommunityEvent`); Viator affiliate page migration for passive commission ([`09`](./SDD/09-modules.md)).
+  - **Traffic (Waze-style):** `TrafficReport` (radar/accident/hazard) with geo + upvote/expiry trust model and GPS push notifications ([`09`](./SDD/09-modules.md), [`11`](./SDD/11-security-auth.md)).
+- **Exit criteria:** users can browse providers, submit events, and post/confirm traffic reports; moderation tooling exists; abuse controls in place.
+- **Depends on:** Phases 1–3 (tenant, analytics, auth, push infra).
+
+### Phase 5 — Monetization
+
+- **Objective:** turn on revenue.
+- **Scope:**
+  - **Subscriptions:** Stripe (web) + RevenueCat (iOS/Android IAP) → unified `Entitlement`; migrate legacy email allow-list subscribers ([`08`](./SDD/08-monetization-freemium.md)).
+  - **Free tier ads:** AdMob (native) + AdSense (web), suppressed for premium; keep first-party `Ad` campaigns ([`08`](./SDD/08-monetization-freemium.md)).
+  - **Pay-to-Promote:** boost mechanics for Marketplace providers and Events (`Promotion` model, no commissions/monthly fees) ([`08`](./SDD/08-monetization-freemium.md)).
+  - **Premium features:** ad-free, real-time GPS alerts, personalized notifications.
+- **Exit criteria:** a user can subscribe on each platform and lose ads; a provider/promoter can purchase a boost; entitlements reconcile across Stripe/RevenueCat webhooks.
+- **Depends on:** Phases 1–4.
+
+---
+
+## 6. Cutover & rollback strategy
+
+- **Strangler-fig:** new backend runs alongside legacy; the compat shim lets us migrate clients endpoint-by-endpoint. Legacy DB stays read-only-replicated into the new one during dual-run.
+- **Per-island flag:** `Island.is_live` gates whether a tenant is served from new vs legacy.
+- **Rollback:** because the shim preserves legacy response shapes and the legacy stack remains deployed, we can repoint DNS/API base back to legacy at any phase boundary.
+
+Details: [`05-data-migration.md`](./SDD/05-data-migration.md).
+
+---
+
+## 7. Assumptions
+
+- `djast` provides the Django project scaffold, opinionated settings, DRF wiring, Celery/Redis, and auth primitives. Where its specifics are unknown, the SDD flags assumptions explicitly in [`12-risks-open-questions.md`](./SDD/12-risks-open-questions.md).
+- The new code lives in the `sao-miguel-hub` repo. These planning docs are committed to the legacy `SaoMiguelBus` repo only because `sao-miguel-hub` does not yet exist in this workspace; on approval they move into `sao-miguel-hub/SDD/`.
+- External APIs (EMSC-CSEM, dados.gov.pt, Viator, Google Maps) remain available under their current terms; rate limits handled via cached Celery sync, not per-request proxying where avoidable.
+
+---
+
+## 8. Next step
+
+**Review this plan and the [`SDD/`](./SDD) documents and approve (or annotate).** No implementation code, components, or API views will be written until approval is explicit.

--- a/SDD/00-overview.md
+++ b/SDD/00-overview.md
@@ -1,0 +1,75 @@
+# SDD 00 — Overview, Vision & Scope
+
+## 1. Vision
+
+**Azores Hub** is a white-labelable mobile + web platform that is the daily-utility companion for residents and visitors of an Azorean island. The first instance, **`sao-miguel-hub`**, supersedes the existing São Miguel Bus app. The same codebase and backend must clone to other islands (Terceira, Faial, Pico, …) by configuration and data only.
+
+It expands the product from a single feature (bus schedules) to a multi-module hub:
+
+- Transit (buses, routes, step-by-step directions) — *migrated from legacy*
+- Local News
+- Earthquake / seismic tracking
+- Marketplace for local services
+- Tourist guide & hiking trails
+- Crowdsourced traffic & navigation alerts
+- Crowdsourced community events & tours
+
+## 2. Why now / problem with the legacy stack
+
+| Area | Legacy reality | Consequence |
+|------|----------------|-------------|
+| Backend framework | Django **3.0.14** (EOL), DRF function-views | Security/maintenance risk; hard to extend |
+| Schedule model | `Route.stops` = stringified Python dict (`str(dict)`, not JSON) | Fragile, unqueryable, no relational integrity |
+| Multi-tenant | None — single island hardcoded (50 km radius around `37.78,-25.50`) | Cannot scale to other islands |
+| Analytics | Single flat `Stat` table; triple client stack (GA + Umami + `/stat`) | Inconsistent, not module-aware, no governance |
+| Privacy | Anonymous-ish but no consent flow, no retention policy, IP/UA handling undefined | GDPR exposure |
+| Monetization | Manual email allow-list "premium"; Stripe only planned | Not real billing; no IAP |
+| Frontend | 2.4k-line `index.html` + global-scoped JS, no build, hardcoded API URL | Unmaintainable, can't reskin, three parallel clients (web, Android, Flutter) |
+
+## 3. Scope
+
+### In scope
+- New backend (`djast`/Django) with tenant root, normalized schema, modular apps.
+- New Expo (React Native + Web) app replacing webapp + native Android + Flutter clients.
+- Migration of all historical data since 2020 (routes, stats, ads, infos, holidays, likes, subscriptions).
+- GDPR consent + analytics governance.
+- Freemium monetization (subscriptions, ads, pay-to-promote).
+- The seven feature modules above.
+
+### Out of scope (for now)
+- Real-time GPS bus positions from operators (no operator feed exists today; "tracking" is currently schedule-math only — see [`09-modules.md`](./09-modules.md)).
+- Non-Azorean regions.
+- Replacing Google Maps as the directions provider.
+
+## 4. Personas
+
+| Persona | Needs |
+|---------|-------|
+| **Resident commuter** | Fast bus search, favorites, offline schedule, traffic alerts, local news |
+| **Tourist** | Trails, POIs, tours (Viator), directions, offline maps, micro-climate weather |
+| **Local tradesperson** | Free Marketplace listing; optional paid promotion |
+| **Event promoter** | Submit events; pay to boost |
+| **Premium subscriber** | Ad-free, GPS alerts, personalized notifications |
+| **Operator / admin** | Manage schedules, ads, moderation, analytics |
+| **DPO / compliance** | Consent records, retention, DSAR fulfillment |
+
+## 5. Success metrics
+
+- **Parity:** 100% of legacy transit search results reproducible on the new stack (validated against `/api/v2/webapp/load`).
+- **Scalability:** spin up a second island with zero code changes (config + data only).
+- **Privacy:** zero raw IP / stable-ID storage without consent; retention job demonstrably anonymizes/deletes after the configured window.
+- **Engagement:** module-level event coverage — every search/filter/engagement in all 7 modules emits a normalized `AnalyticsEvent`.
+- **Revenue:** functional subscribe → ad-free flow on all three platforms; functional pay-to-promote purchase.
+
+## 6. Glossary
+
+| Term | Meaning |
+|------|---------|
+| **Island / Hub** | Tenant root entity; one row per island instance |
+| **`ISLAND_KEY`** | Stable slug identifying the active tenant (e.g. `sao-miguel`) |
+| **CMP** | Consent Management Platform (frontend consent UI + backend record) |
+| **DSAR** | Data Subject Access Request (GDPR export/delete) |
+| **Compat shim** | Adapter exposing new data through legacy `/api/v1` + `/api/v2` shapes |
+| **`djast`** | The team's AI-agentic Django boilerplate used as backend foundation |
+| **Pay-to-Promote** | Monetization where listings are free; only boosting is paid |
+| **Strangler-fig** | Migration pattern: new system grows around legacy until legacy is removed |

--- a/SDD/01-architecture.md
+++ b/SDD/01-architecture.md
@@ -1,0 +1,100 @@
+# SDD 01 — System Architecture & Tech Stack
+
+## 1. High-level architecture
+
+Azores Hub is a **modular monolith backend** + a **single cross-platform client**. We deliberately avoid microservices: the modules share tenancy, auth, analytics, consent, and billing infrastructure, and the volume does not justify the operational cost of many services.
+
+```
+Expo app (RN + Web)  ──HTTPS/JSON──▶  djast Django backend (DRF)  ──▶ PostgreSQL
+   │  Android / iOS / Web                  │  modular apps              (tenant-scoped)
+   │  theme + i18n by ISLAND_KEY           │  Celery workers ──▶ Redis (broker + cache)
+   └─ consent (CMP) before any analytics   └─ external integrations (EMSC, dados.gov.pt, RSS, Maps)
+```
+
+## 2. Backend tech stack
+
+| Concern | Choice | Notes |
+|---------|--------|-------|
+| Framework | Django (current LTS) via **`djast`** | Replaces Django 3.0.14 |
+| API | Django REST Framework, **ViewSets + Routers** | Replaces ad-hoc `@api_view` function views |
+| DB | PostgreSQL | Already used in legacy production |
+| Async/cron | **Celery + Celery Beat**, Redis broker | News scraping, EMSC/trails sync, retention jobs, push fan-out |
+| Cache | Redis | Bootstrap payloads, external-feed caching, rate-limit counters |
+| Auth | djast auth + DRF token/JWT; anonymous-allowed read paths | See [`11-security-auth.md`](./11-security-auth.md) |
+| Storage | Object storage (S3-compatible) + CDN | Provider/event media, offline map tiles |
+| Search/matching | Postgres `pg_trgm` for fuzzy stop/place names | Replaces ad-hoc `cleaned_name` `__contains` |
+| Payments | Stripe (web) + RevenueCat (mobile IAP) | See [`08-monetization-freemium.md`](./08-monetization-freemium.md) |
+| Observability | Structured logging, Sentry, request/Celery metrics | — |
+
+### djast assumptions
+
+`djast` is taken to provide: project scaffold, opinionated settings split (`base`/`dev`/`prod`), DRF + CORS wiring, Celery/Redis, a custom `User` model, environment/secret loading, and agent-friendly conventions. Anything we depend on that `djast` may *not* provide is flagged in [`12-risks-open-questions.md`](./12-risks-open-questions.md).
+
+## 3. Backend project layout (`sao-miguel-hub/backend/`)
+
+```
+backend/
+├── config/                 # djast settings (base/dev/prod), urls, celery, wsgi/asgi
+├── apps/
+│   ├── tenancy/            # Island/Hub root, scoping middleware, base models
+│   ├── accounts/           # User, profiles, consent links
+│   ├── analytics/          # AnalyticsEvent, ingestion, retention tasks
+│   ├── consent/            # ConsentRecord, CMP support, DSAR commands
+│   ├── billing/            # Entitlement, Stripe + RevenueCat webhooks, Promotion
+│   ├── transit/            # Operator, Line, Stop, Trip, StopTime, Calendar, directions proxy
+│   ├── news/               # NewsSource, NewsArticle, RSS Celery tasks
+│   ├── seismic/            # SeismicEvent, FeltReport, EMSC sync
+│   ├── marketplace/        # ServiceProvider, ServiceCategory, Review
+│   ├── trails/             # Trail, TrailStage, POI; dados.gov.pt sync
+│   ├── traffic/            # TrafficReport, confirmations, push
+│   ├── events/             # CommunityEvent, ViatorListing
+│   └── compat/             # Legacy /api/v1 + /api/v2 shim views
+├── common/                 # shared serializers, pagination, permissions, geo utils
+└── tests/
+```
+
+Each feature app owns its `models.py`, `serializers.py`, `views.py` (ViewSets), `tasks.py` (Celery), `admin.py`, and `migrations/`.
+
+## 4. Frontend tech stack
+
+| Concern | Choice |
+|---------|--------|
+| Framework | **Expo (React Native)** with **Expo Router** (file-based routing) |
+| Targets | Android, iOS, Web (`react-native-web`) from one codebase |
+| Language | TypeScript |
+| State/data | TanStack Query (server cache) + lightweight client store (Zustand) |
+| Styling/theme | Theme tokens from island config; no hardcoded brand colors |
+| i18n | port the 8 existing locales (`pt,en,es,de,fr,it,uk,zh`) into a typed i18n lib |
+| Maps | `react-native-maps` (native) + Leaflet/MapLibre (web); offline tiles via MapLibre + cached MBTiles |
+| Push | Expo Notifications |
+| Payments | Stripe web SDK + RevenueCat SDK (mobile) |
+
+Frontend layout and routing: [`10-frontend-architecture.md`](./10-frontend-architecture.md).
+
+## 5. Repository strategy
+
+`sao-miguel-hub` is a **monorepo** with `backend/` and `app/` (Expo) plus `SDD/` and `infra/`. A monorepo keeps the API contract and client types in sync (shared OpenAPI-generated types) and matches "one platform" framing. Per-island instances are **deployments of the same repo**, differentiated by env/config and tenant data — *not* repo forks.
+
+## 6. Environments & config
+
+| Env | Backend | Frontend |
+|-----|---------|----------|
+| dev | SQLite or local Postgres, Celery eager, fake external feeds | Expo dev client, `EXPO_PUBLIC_API_URL` → localhost |
+| staging | Postgres, real Celery, sandbox Stripe/RevenueCat | points at staging API |
+| prod | Postgres, Redis, real feeds & billing | per-island build with island config |
+
+**Critical fix vs legacy:** the API base URL must be an environment variable (`EXPO_PUBLIC_API_URL`), not hardcoded as `https://api.saomiguelbus.com` the way the legacy webapp does it.
+
+## 7. Cross-cutting infrastructure
+
+- **Tenancy** ([`02`](./02-multi-island-whitelabel.md)) — middleware resolves the active `Island` from the `X-Island` header / subdomain and scopes all querysets.
+- **Analytics** ([`06`](./06-analytics-tracking.md)) — one ingestion endpoint, one `AnalyticsEvent` table, consent-gated.
+- **Consent & governance** ([`07`](./07-gdpr-data-governance.md)) — CMP, pseudonymization, retention, DSAR.
+- **Billing** ([`08`](./08-monetization-freemium.md)) — entitlement reconciliation across Stripe + RevenueCat.
+
+## 8. Non-functional requirements
+
+- **Performance:** bootstrap payload (`/bootstrap`) cached in Redis per island; transit search < 200 ms server-side (legacy target).
+- **Offline:** transit schedule + trails + last-known news cached client-side; offline map tiles for trails.
+- **Availability:** strangler-fig dual-run keeps legacy as fallback during migration.
+- **Portability:** zero island-specific code paths; everything tenant-driven.

--- a/SDD/02-multi-island-whitelabel.md
+++ b/SDD/02-multi-island-whitelabel.md
@@ -1,0 +1,97 @@
+# SDD 02 — Multi-Island Scalability & White-Labeling
+
+The single most important architectural change. Everything else hangs off it.
+
+## 1. The tenant root: `Island`
+
+```
+Island (apps/tenancy)
+  key            slug, unique, immutable   e.g. "sao-miguel"
+  name           display name              e.g. "São Miguel"
+  archipelago    e.g. "Azores"
+  is_live        bool — gate new vs legacy serving
+  center_lat     float                     e.g. 37.7822
+  center_lng     float                     e.g. -25.4998
+  radius_km      int   geo-fence for data validity (legacy hardcoded 50)
+  timezone       e.g. "Atlantic/Azores"
+  default_locale e.g. "pt"
+  locales        list[str]                 supported languages
+  theme          JSON  (see §4)
+  feature_flags  JSON  per-module enable/disable
+  created_at / updated_at
+```
+
+`Island` (alias **Hub**) is the parent of every domain row. There is exactly one per deployment-as-island, but the schema supports many in one DB so a single backend instance can serve multiple islands (multi-tenant) *or* be cloned per island (single-tenant) — both work.
+
+## 2. Tenant-scoped base model
+
+Every domain model inherits:
+
+```
+TenantScopedModel (abstract)
+  island = ForeignKey(Island, on_delete=PROTECT, db_index=True)
+  objects = TenantManager()   # filters by active island from request context
+```
+
+- `TenantManager` reads the active island from a thread-local / contextvar set by middleware.
+- A `for_island(island)` escape hatch exists for Celery tasks and cross-tenant admin.
+- DB indexes are **composite, island-first** (e.g. `(island, cleaned_name)`), so per-island queries stay fast as more islands are added.
+
+## 3. Request scoping
+
+```
+Client                         Backend
+──────                         ───────
+X-Island: sao-miguel    ─────▶ TenantMiddleware resolves Island
+(or subdomain                  → sets active-island contextvar
+ sao-miguel.azoreshub.app)     → all TenantManager queries auto-filter
+                               → 400 if island unknown / not is_live
+```
+
+Resolution order: explicit `X-Island` header → subdomain → `?island=` query param (compat) → configured default. The legacy compat shim ([`04`](./04-api-design.md)) always injects `sao-miguel`.
+
+## 4. Frontend white-labeling
+
+A single config object per island drives all branding. Source of truth is the backend `Island.theme`, mirrored into a frontend build-time/runtime config so the app can theme before the first network call.
+
+```ts
+// app/config/island.ts  (selected by EXPO_PUBLIC_ISLAND_KEY at build/runtime)
+export interface IslandConfig {
+  islandKey: string;          // "sao-miguel"
+  islandName: string;         // "São Miguel"
+  primaryColor: string;       // PRIMARY_COLOR
+  secondaryColor: string;     // SECONDARY_COLOR
+  accentColor: string;
+  logoLight: ImageRef;
+  logoDark: ImageRef;
+  appIcon: ImageRef;
+  splash: ImageRef;
+  defaultLocale: string;
+  enabledModules: ModuleKey[]; // mirrors Island.feature_flags
+  mapCenter: { lat: number; lng: number };
+  storeLinks: { android?: string; ios?: string };
+}
+```
+
+Rules:
+- **No literal brand colors anywhere in components** — only theme tokens (`theme.primary`, etc.).
+- Swapping island = swapping `EXPO_PUBLIC_ISLAND_KEY` + assets; no component edits.
+- Module visibility is data-driven (`enabledModules`) so an island can launch with transit-only and add modules later.
+- App-store builds are produced per island via Expo build profiles (EAS) parameterized by `ISLAND_KEY`.
+
+## 5. Adding a new island (operational runbook, post-build)
+
+1. Create `Island` row (key, geo, timezone, locales, theme, flags).
+2. Load that island's transit/trails/etc. data (or none, to start empty).
+3. Add an EAS build profile + assets for the new `ISLAND_KEY`.
+4. Point a subdomain at the API. Done — zero code changes.
+
+## 6. What this replaces in legacy
+
+| Legacy | New |
+|--------|-----|
+| Hardcoded center `(37.782213, -25.499806)` + 50 km radius in `is_within_50km_radius()` | `Island.center_lat/lng/radius_km` |
+| `Atlantic/Azores` literal in GMaps proxy | `Island.timezone` |
+| Single set of routes/stops/ads | All tenant-scoped by `island` FK |
+| Brand color `#28a745` baked into manifest/CSS | `Island.theme.primaryColor` token |
+| Per-island = new repo/app | Per-island = config + data |

--- a/SDD/03-data-model.md
+++ b/SDD/03-data-model.md
@@ -1,0 +1,186 @@
+# SDD 03 — Data Model & Legacy Mapping
+
+All models inherit `TenantScopedModel` (`island` FK) unless noted. Types are indicative; exact field options finalized during Phase 1. This doc defines **what** we store; migration mechanics are in [`05-data-migration.md`](./05-data-migration.md).
+
+## 1. Design decisions vs legacy
+
+The legacy schema (see audit in repo history) is **denormalized and fragile**:
+
+- `Route.stops` is a *stringified Python dict* (`{'Stop A': '08h30', ...}`) in a JSONField — not valid JSON, parsed with `ast.literal_eval`.
+- No FK between routes and stops; stop names are free strings reconciled by `cleaned_name` fuzzy match.
+- `Trip`/`TripStop`/`Data` are a parallel Google-Maps-derived system with a 30-day TTL, not used for v2 search.
+- Multilingual content is split across `titlePT/titleEN/...` columns (`Info`) and per-route JSON.
+
+We normalize transit into a GTFS-inspired relational model, keep multilingual content as structured JSON, and scope everything to `Island`.
+
+## 2. Transit module (`apps/transit`)
+
+```
+Operator
+  name            "CRP" | "AVM" | "Varela"   (legacy: route-number prefix convention)
+  contact         JSON (phone, email, url)
+
+Line                       # a bus line (legacy Route.route, e.g. "208")
+  operator        FK Operator
+  code            "208"
+  display_name    optional human name
+  disabled        bool                       (legacy Route.disabled)
+
+Stop                       # canonical stop (legacy Stop)
+  name            str
+  cleaned_name    str  (lowercase, accents stripped; index (island, cleaned_name))
+  latitude        float
+  longitude       float
+  POINT geometry  (optional PostGIS later)
+
+Calendar                   # day-type service pattern (legacy type_of_day enum)
+  service_type    "WEEKDAY" | "SATURDAY" | "SUNDAY"
+  # holidays map to SUNDAY via Holiday table (legacy get_type_of_day())
+
+Trip                       # one scheduled run of a Line on a Calendar
+  line            FK Line
+  calendar        FK Calendar
+  headsign        optional
+  direction       optional
+  information      FK RouteInfo (nullable)   # multilingual notice
+  likes / dislikes int                       (legacy Route.likes/dislikes)
+  source          "operator" | "gmaps"       # replaces Route vs Trip split
+
+StopTime                   # ordered stop+time on a Trip  (REPLACES stringified dict)
+  trip            FK Trip
+  stop            FK Stop
+  sequence        int
+  departure_time  Time      ("08h30" → 08:30)
+  arrival_time    Time (nullable)
+  unique_together (trip, sequence)
+
+RouteInfo                  # multilingual operator notice (legacy Info + Route.information)
+  text            JSON {"pt": "...", "en": "...", "es": ..., "fr": ..., "de": ...}
+  source          str
+  company         str
+  start / end     datetime
+
+Holiday                    # (legacy Holiday)
+  date            date
+  name            str
+
+RouteFeedback              # normalized likes/dislikes audit (optional, anti-abuse)
+  trip            FK Trip
+  session_hash    str       # pseudonymous (see GDPR)
+  vote            "like" | "dislike"
+```
+
+**Key win:** `StopTime` makes schedules queryable (`WHERE stop_id=? AND departure_time>=?`) instead of substring-matching a stringified dict.
+
+### Legacy → new transit mapping
+
+| Legacy | New |
+|--------|-----|
+| `Route.route` | `Line.code` |
+| `Route.stops` (str-dict) | rows in `StopTime` (parsed) |
+| `Route.cleaned_stops` | derived; dropped (use `StopTime` + `Stop.cleaned_name`) |
+| `Route.type_of_day` | `Calendar.service_type` |
+| `Route.information` (JSON) | `RouteInfo.text` |
+| `Route.disabled` | `Line.disabled` / `Trip` filtered |
+| `Route.likes/dislikes` | `Trip.likes/dislikes` |
+| `Stop.{name,cleaned_name,lat,lng}` | `Stop.*` (1:1) |
+| `Trip`/`TripStop`/`Data` (GMaps) | folded into `Trip(source="gmaps")` + on-demand proxy; `Data` cache → Redis, not a table |
+| `Info.titleXX/messageXX` | `RouteInfo.text` JSON |
+| `Holiday` | `Holiday` (1:1) |
+| `Variables` (version/maps flags) | `Island.feature_flags` + app config |
+| `Group` (geographic stop groups for ads/stats) | `StopGroup` (kept for ad targeting + analytics rollups) |
+
+## 3. Accounts & consent (`apps/accounts`, `apps/consent`)
+
+```
+User (djast custom user)
+  email, auth fields, locale, created_at
+  # anonymous usage allowed; account optional except for community features
+
+ConsentRecord
+  user            FK User (nullable for anonymous)
+  session_hash    str
+  purposes        JSON  {"analytics": true, "ads": false, "personalization": true}
+  policy_version  str
+  granted_at      datetime
+  withdrawn_at    datetime (nullable)
+```
+
+## 4. Analytics (`apps/analytics`)
+
+```
+AnalyticsEvent              # universal, replaces flat Stat (see SDD 06)
+  module          "transit"|"news"|"earthquakes"|"marketplace"|"trails"|"traffic"|"events"
+  event_type      "search"|"filter"|"view"|"engage"|"load" ...
+  properties      JSON  (module-specific payload; no PII)
+  session_hash    str   (pseudonymous; see SDD 07)
+  consent_state   JSON snapshot at emit time
+  platform        "android"|"ios"|"web"
+  locale          str
+  app_version     str
+  occurred_at     datetime
+  # NO raw IP, NO stable user id unless consented
+```
+
+### Legacy → analytics mapping
+
+| Legacy `Stat` field | New |
+|---------------------|-----|
+| `request` (`get_route`,`get_directions`,`android_load`,`find_routes`) | `module="transit"`, `event_type` mapped |
+| `origin`/`destination`/`time`/`type_of_day` | `properties` JSON |
+| `platform`/`language` | `platform`/`locale` |
+| `timestamp` | `occurred_at` |
+| `Ad.seen`/`clicked` | `AnalyticsEvent(module varies, event_type="impression"/"click")` + counters |
+| `EmailOpen` | `AnalyticsEvent(module="news"/"comms")` or retired |
+
+## 5. Billing (`apps/billing`)
+
+```
+Entitlement                 # unifies Stripe + RevenueCat + legacy allow-list
+  user            FK User (or email for legacy)
+  tier            "free" | "premium"
+  source          "stripe" | "revenuecat" | "legacy_email"
+  external_id     str
+  status          "active"|"trialing"|"canceled"|"expired"
+  current_period_end datetime (nullable)
+  features        JSON  ["ad_removal","gps_alerts","personalized_notifications"]
+
+Promotion                   # Pay-to-Promote (marketplace/events)
+  target_type     "service_provider" | "community_event"
+  target_id       int
+  status          "active"|"scheduled"|"expired"
+  start / end     datetime
+  tier            str
+```
+
+### Legacy → billing mapping
+
+| Legacy `Subscription` | New `Entitlement` |
+|-----------------------|-------------------|
+| `email` | `user`/`email` |
+| `is_active` | `status="active"`, `tier="premium"`, `source="legacy_email"` |
+| `verification_count` | dropped (telemetry only) |
+| hardcoded `features` | `features` JSON |
+
+## 6. Other modules (summarized; detail in [`09-modules.md`](./09-modules.md))
+
+```
+news/        NewsSource(name,url,rss_url,language)  NewsArticle(title,summary,url,published_at,source,categories)
+seismic/     SeismicEvent(emsc_id,magnitude,depth,lat,lng,occurred_at,region)  FeltReport(event,session_hash,lat,lng,intensity)
+marketplace/ ServiceCategory(name,icon)  ServiceProvider(name,category,bio,hourly_rate,phone,geo,is_promoted,rating)  Review(provider,session_hash,rating,text)
+trails/      Trail(name,difficulty,length_km,geojson,source_ref)  TrailStage(...)  POI(name,type,geo)
+traffic/     TrafficReport(type,lat,lng,session_hash,created_at,expires_at,confirmations,status)
+events/      CommunityEvent(title,description,start,end,venue,geo,is_promoted,status)  ViatorListing(...)
+ads/         Ad(...)  StopGroup(...)   # first-party ad campaigns, migrated from legacy Ad/Group
+```
+
+`Ad` is migrated largely as-is (it already has platform/status/action/target/seen/clicked) but gains an `island` FK and integrates with the consent/ads purpose.
+
+## 7. Indexing & integrity highlights
+
+- All tenant tables: composite index `(island, <lookup>)`.
+- `Stop`: `(island, cleaned_name)` + GIN trigram on `cleaned_name` for fuzzy search (replaces `__contains`).
+- `StopTime`: `(stop, departure_time)` and `(trip, sequence)`.
+- `AnalyticsEvent`: `(island, module, occurred_at)`; consider monthly partitioning given append-only high volume.
+- `Entitlement`: unique `(source, external_id)`; index on `user`.
+- FKs use `PROTECT` on `island`, `CASCADE` within a module where safe.

--- a/SDD/04-api-design.md
+++ b/SDD/04-api-design.md
@@ -1,0 +1,80 @@
+# SDD 04 — API Design, Versioning & Legacy Compatibility
+
+## 1. Conventions
+
+- **DRF ViewSets + Routers** (replacing legacy `@api_view` function views).
+- **Resource-oriented**, plural nouns: `/api/v3/transit/lines`, `/api/v3/news/articles`.
+- **Tenant context** via `X-Island` header (or subdomain); never trust client-supplied island in the body.
+- **Auth:** anonymous allowed for read-only public data; token/JWT required for writes that need identity (reviews, event submission, account-bound favorites). See [`11-security-auth.md`](./11-security-auth.md).
+- **Pagination:** cursor pagination on list endpoints (analytics, news, reports).
+- **Errors:** consistent envelope `{ "error": { "code", "message", "details" } }`.
+- **Types:** OpenAPI schema generated server-side; TypeScript client types generated for the Expo app (single source of truth).
+
+## 2. New API surface (`/api/v3`)
+
+| Module | Representative endpoints |
+|--------|--------------------------|
+| Bootstrap | `GET /api/v3/bootstrap` → island config, enabled modules, holidays, active infos (replaces `/api/v2/webapp/load`) |
+| Transit | `GET /transit/stops`, `GET /transit/search?origin=&destination=&day=&start=`, `GET /transit/lines/{id}`, `GET /transit/directions` (Maps proxy), `POST /transit/trips/{id}/vote` |
+| News | `GET /news/articles?category=`, `GET /news/sources` |
+| Seismic | `GET /seismic/events?since=`, `POST /seismic/events/{id}/felt` |
+| Marketplace | `GET /marketplace/providers?category=&q=`, `GET /marketplace/categories`, `POST /marketplace/providers/{id}/reviews` |
+| Trails | `GET /trails`, `GET /trails/{id}`, `GET /trails/pois` |
+| Traffic | `GET /traffic/reports?bbox=`, `POST /traffic/reports`, `POST /traffic/reports/{id}/confirm` |
+| Events | `GET /events?from=&to=`, `POST /events`, `GET /events/tours` (Viator) |
+| Analytics | `POST /analytics/events` (consent-gated ingestion) |
+| Consent | `GET/POST /consent`, `POST /privacy/dsar/export`, `POST /privacy/dsar/delete` |
+| Billing | `GET /billing/entitlement`, `POST /billing/webhooks/stripe`, `POST /billing/webhooks/revenuecat`, `POST /promotions` |
+
+## 3. Versioning strategy
+
+- New canonical API is **`/api/v3`** (legacy already used v1 + v2).
+- `/api/v1` and `/api/v2` are served by the **compat app** (`apps/compat`) translating new models → old shapes.
+- Deprecation: compat endpoints emit a `Deprecation` + `Sunset` header; we track their usage via analytics to know when it's safe to remove.
+
+## 4. Legacy compatibility shim (critical for zero-downtime cutover)
+
+Existing clients in the wild that must keep working during migration:
+
+| Client | Depends on |
+|--------|-----------|
+| Web PWA (current) | `/api/v2/webapp/load`, `/api/v2/stops`, `/api/v2/route`, `/api/v1/gmaps`, `/api/v1/stat`, `/api/v1/ad`, `/api/v1/ad/click`, `/api/v2/like|dislike/{id}`, `/api/v1/subscription/verify/` |
+| Native Android (Play Store) | `/api/v2/android/load`, `/api/v1/stat`, `/api/v1/ad` |
+| Flutter (release) | `/api/v1/stops`, `/api/v2/android/load` |
+| Desktop web | `/api/v1/stops`, `/api/v1/route` |
+
+The compat app re-implements each of these against the new schema, always scoped to `island=sao-miguel`:
+
+```
+GET /api/v2/route?origin=&destination=&day=&start=
+   → resolve origin/destination Stop via cleaned_name trigram match
+   → query StopTime/Trip on the right Calendar
+   → serialize to legacy ReturnRoute dict shape (start/end/stops map/likes_percent...)
+
+GET /api/v2/webapp/load
+   → assemble routes + stops + holidays + infos in legacy payload shape
+
+POST /api/v1/stat?request=...&origin=...      (params in query string, as legacy does)
+   → translate into AnalyticsEvent(module="transit", ...) under consent rules
+
+POST /api/v1/subscription/verify/  {email}
+   → look up Entitlement(source="legacy_email"/...) → legacy response
+        { hasActiveSubscription, subscriptionType, expiresAt, features, message }
+```
+
+The shim is **write-translating** for `/stat` (legacy stat → AnalyticsEvent) and **read-translating** for everything else. It lets us migrate the data and backend first, then move clients to v3 at our own pace.
+
+## 5. Directions / Google Maps proxy
+
+Legacy `/api/v1/gmaps` is a server-side proxy (holds the Google key, validates `key=AUTH_KEY` + client `version>=5`, geo-fences results to the island radius, caches raw responses in the `Data` table, and parses them into `Trip`/`TripStop`).
+
+New design:
+- Keep server-side proxy (don't ship Maps keys to clients — legacy leaks both the proxy `AUTH_KEY` and the Maps key in client source; we fix this — see [`11`](./11-security-auth.md)).
+- Cache raw responses in **Redis** keyed by `(island, origin, destination, day, start, locale)` instead of an unbounded `Data` table.
+- Geo-fence using `Island.center/radius_km` instead of the hardcoded constant.
+- Optionally persist derived trips as `Trip(source="gmaps")` for analytics, with TTL cleanup via Celery (replaces the manual 30-day delete loop).
+
+## 6. Rate limiting & abuse
+
+- DRF throttles per session_hash/IP-bucket on write endpoints (votes, reviews, traffic reports, felt reports, event submissions).
+- Crowdsourced writes require either an account or a signed anonymous session token; trust/confirmation model in [`11`](./11-security-auth.md).

--- a/SDD/05-data-migration.md
+++ b/SDD/05-data-migration.md
@@ -1,0 +1,98 @@
+# SDD 05 — Data Migration Strategy (2020+)
+
+Goal: migrate **all** historical data from the legacy Postgres DB into the new tenant-scoped schema without data loss, parsing the fragile legacy formats, and pseudonymizing analytics in flight.
+
+## 1. Sources
+
+| Source | Contents |
+|--------|----------|
+| Legacy production Postgres | `Route`, `Stop`, `Trip`/`TripStop`/`Data`, `Stat`, `Ad`, `Group`, `Info`, `Holiday`, `Variables`, `Subscription`, `AIFeedback`, `EmailOpen`, likes/dislikes |
+| `SaoMiguelBus-api/src/data.json` | ~2022 fixture dump (cross-check / earliest seed) |
+| `scripts/data/*.txt`, `scripts/csv/*.csv`, `scripts/groups.json` | original operator timetables + geographic groups (source-of-truth fallback) |
+
+## 2. The hard part: `Route.stops`
+
+Legacy stores schedules as a **stringified Python dict**, e.g.:
+
+```python
+"{'Ponta Delgada': '08h30', 'Lagoa': '08h45', 'Vila Franca': '09h10'}"
+```
+
+This is **not JSON** (single quotes, `HhMM` time format). The ETL must:
+
+1. Parse with `ast.literal_eval` (never `json.loads`).
+2. Normalize times `"08h30"` → `time(8, 30)`.
+3. For each `(stop_name, time)` create a `StopTime` with `sequence` from dict insertion order.
+4. Resolve `stop_name` → `Stop` FK via exact match, else `cleaned_name` (accent-stripped, lowercased) trigram match; unmatched names are logged and either auto-created as a `Stop` (if coordinates available from `Stop`/`TripStop`/groups) or flagged for manual review.
+5. Create `Line` from `Route.route`, `Calendar` from `type_of_day`, `Trip` linking them, and `RouteInfo` from `Route.information`.
+
+## 3. ETL pipeline
+
+Implemented as idempotent Django management commands (`migrate_legacy <model>`), run in dependency order:
+
+```
+1. islands         → create Island(key="sao-miguel", center/radius/timezone/theme from legacy constants)
+2. operators       → derive from Line code prefixes (CRP=1*, AVM=2*, Varela=3*) + scripts metadata
+3. stops           → Stop (1:1) ; backfill missing from TripStop + groups.json
+4. stop_groups     → Group → StopGroup
+5. calendars       → 3 fixed rows (WEEKDAY/SATURDAY/SUNDAY)
+6. holidays        → Holiday (1:1)
+7. lines+trips+stoptimes → parse Route.stops dicts (the hard part, §2)
+8. route_info      → Info + Route.information → RouteInfo
+9. ads             → Ad (+island) ; preserve seen/clicked
+10. feedback votes → Route/Trip likes/dislikes → Trip counters
+11. subscriptions  → Subscription → Entitlement(source="legacy_email")
+12. analytics      → Stat → AnalyticsEvent (pseudonymized, §4)
+```
+
+Each command:
+- Is **idempotent** (re-runnable; upserts by natural key).
+- Writes a **migration report** (counts in/out, unmatched stops, parse failures).
+- Tags rows with `legacy_id` (kept in a `legacy_ref` JSON/column) for traceability and dual-read validation.
+
+## 4. Analytics migration with pseudonymization
+
+`Stat` is high-volume, append-only, and already mostly anonymous (no user/session id). On migration:
+
+- `request` → `module`/`event_type`; `origin/destination/time/type_of_day` → `properties`.
+- No IP exists in legacy `Stat`, so nothing to scrub there; we still assign a **synthetic `session_hash = NULL`/`"legacy"`** marker (we cannot reconstruct sessions).
+- Historical events older than the retention window ([`07`](./07-gdpr-data-governance.md)) are migrated **already-anonymized** (aggregated counts retained, row-level detail dropped if beyond retention) to start compliant.
+- `consent_state` for legacy rows = `{"migrated": true}` (pre-CMP; treated as aggregate analytics only).
+
+## 5. Validation (parity gate)
+
+Before cutover, prove equivalence:
+
+1. **Search parity:** for a sampled matrix of `(origin, destination, day, start)`, compare new `/transit/search` (and compat `/api/v2/route`) against recorded legacy responses; require identical result sets.
+2. **Bootstrap parity:** diff new `/api/v2/webapp/load` (compat) vs legacy production payload (stops list, holidays, infos, routes count).
+3. **Counts:** every legacy row accounted for (migrated / intentionally-dropped / flagged), reconciled in the migration report.
+4. **Spot-check unmatched stops** list is empty or manually resolved.
+
+## 6. Cutover (strangler-fig, reversible)
+
+```
+Stage A  Dual-run: new backend reads from a replica/snapshot of legacy data via ETL.
+         Legacy stack still serves all live traffic.
+Stage B  Flip compat shim to new backend for read endpoints behind Island.is_live.
+         Validate parity in production (shadow traffic / canary).
+Stage C  Point clients' API base URL to new backend (compat shim). Legacy serves as hot fallback.
+Stage D  Migrate clients to /api/v3 module-by-module; watch Deprecation header usage.
+Stage E  Decommission legacy once compat usage → 0.
+```
+
+**Rollback:** at A–C, repoint to legacy (still deployed). After D, legacy remains a fallback until E.
+
+## 7. Ongoing sync during dual-run
+
+For the window where both stacks accept writes (mainly `/stat` and likes), the compat shim writes to the **new** DB as the system of record; a one-way backfill job reconciles any writes that still landed on legacy until clients are fully cut over.
+
+## 8. Data we deliberately drop or fold
+
+| Legacy | Disposition |
+|--------|-------------|
+| `Data` (raw GMaps JSON cache table) | Not migrated; replaced by Redis cache |
+| `Route.cleaned_stops` | Recomputed from `StopTime` |
+| `Variables` | Folded into `Island.feature_flags` |
+| `Subscription.verification_count` | Dropped (telemetry only) |
+| `AIFeedback`, `EmailOpen` | Migrated to `AnalyticsEvent` if still useful, else archived to cold storage |
+| `Trip`/`TripStop` 30-day GMaps rows | Not migrated (ephemeral by design) |

--- a/SDD/06-analytics-tracking.md
+++ b/SDD/06-analytics-tracking.md
@@ -1,0 +1,74 @@
+# SDD 06 — Module-Wide Search Analytics & Tracking
+
+## 1. Problem with legacy tracking
+
+Three uncoordinated systems:
+- **Server `Stat`** — one flat table, only transit events (`get_route`, `get_directions`, `android_load`, `find_routes`), params crammed into a query string `POST`.
+- **Google Analytics** (`gtag`, `G-YSWK1F7F0B`) — loaded unconditionally, before any consent.
+- **Umami** — self-hosted, with `data-umami-event` attributes everywhere.
+
+No module awareness beyond transit, no consent gating, no normalization.
+
+## 2. Target: one normalized event spine
+
+Every meaningful interaction across **all 7 modules** emits an `AnalyticsEvent` through one ingestion endpoint. Third-party analytics (GA/Umami) become optional, consent-gated, and secondary — the first-party `AnalyticsEvent` table is the system of record.
+
+```
+AnalyticsEvent
+  island          FK (tenant)
+  module          transit | news | earthquakes | marketplace | trails | traffic | events
+  event_type      search | filter | view | engage | impression | click | load | submit | confirm
+  properties      JSON   # normalized per (module, event_type), NO PII
+  session_hash    str    # pseudonymous rolling hash (see SDD 07), NULL if no analytics consent
+  consent_state   JSON   # snapshot of purposes at emit time
+  platform        android | ios | web
+  locale / app_version
+  occurred_at
+```
+
+### Normalized property contracts (examples)
+
+| module | event_type | properties |
+|--------|-----------|------------|
+| transit | search | `{origin, destination, day_type, start_time, results_count}` |
+| transit | filter | `{filter: "favorites"|"operator", value}` |
+| news | search | `{query, category, results_count}` |
+| earthquakes | engage | `{action: "felt", event_id, intensity}` |
+| marketplace | search | `{query, category, results_count}` |
+| marketplace | engage | `{action: "call"|"review"|"view", provider_id}` |
+| trails | view | `{trail_id, difficulty}` |
+| traffic | submit | `{report_type, has_location: true}` |
+| events | engage | `{action: "view"|"submit"|"promote", event_id}` |
+
+Property schemas are validated server-side (a registry per module/event_type) to keep the table analyzable.
+
+## 3. Ingestion
+
+```
+POST /api/v3/analytics/events
+  body: { events: [ {module, event_type, properties, occurred_at}, ... ] }
+  headers: X-Island, (optional) auth
+```
+
+- **Client batches** events and flushes periodically / on background — efficient and offline-friendly.
+- Server **derives** `session_hash`, `consent_state`, `platform`, `locale`, `app_version`; client never sends IP/user id.
+- If the session has **no analytics consent**, the server stores an aggregate-only counter (or drops row-level), never `session_hash`. See [`07`](./07-gdpr-data-governance.md).
+- Legacy `POST /api/v1/stat?...` is translated into this by the compat shim.
+
+## 4. Client SDK contract (Expo)
+
+A thin `track(module, eventType, properties)` helper:
+- No-ops for purposes the user hasn't consented to.
+- Buffers in memory + AsyncStorage, flushes in batches.
+- Strips anything that looks like PII before sending (defense in depth).
+- Mirrors to GA/Umami **only** if the corresponding consent purpose is granted.
+
+## 5. Reporting
+
+- Admin dashboards query `AnalyticsEvent` with `(island, module, occurred_at)` filters.
+- Rollups (top origins/destinations, loads by language, group impressions — the legacy `/statistics` dashboard equivalents) become materialized/aggregate queries, computed by Celery into summary tables so raw rows can be deleted on retention without losing trends.
+- Ad impression/click analytics (legacy `Ad.seen/clicked`, `/stats/group`) map to `module-scoped` impression/click events + counters.
+
+## 6. Migration
+
+Historical `Stat` rows → `AnalyticsEvent` (see [`05-data-migration.md`](./05-data-migration.md) §4). Aggregate summaries computed for pre-retention history so dashboards keep continuity after raw rows age out.

--- a/SDD/07-gdpr-data-governance.md
+++ b/SDD/07-gdpr-data-governance.md
@@ -1,0 +1,74 @@
+# SDD 07 — GDPR Compliance & Data Governance
+
+Strict requirement. Privacy is designed in, not bolted on. Four pillars: **data minimization/anonymization**, **consent**, **retention**, **DSAR readiness**.
+
+## 1. Data minimization & pseudonymization
+
+- **No raw IP addresses** persisted with analytics. If IP is needed transiently (geo, abuse), it is used in-memory and discarded; never written to `AnalyticsEvent`.
+- **No stable user IDs** in analytics unless the user is authenticated *and* consented to personalization.
+- **Session hashing:** clients/anonymous sessions are identified by a `session_hash`:
+  ```
+  session_hash = HMAC_SHA256(server_secret, raw_session_id + island_key + rotating_salt)
+  ```
+  - `rotating_salt` rotates (e.g. daily) so hashes are **not** linkable across long periods → pseudonymous, not a permanent identifier.
+  - Without analytics consent, `session_hash` is `NULL` and only aggregate counters increment.
+- Free-text fields that could carry PII (reviews, event descriptions, traffic notes) are flagged as "user content," subject to DSAR, and never copied into analytics.
+
+## 2. Consent Management Platform (CMP)
+
+Frontend flow ([`10-frontend-architecture.md`](./10-frontend-architecture.md)):
+
+```
+First launch → CMP screen (before GA/Umami/AdMob/AdSense load, before any AnalyticsEvent)
+  Purposes (granular, default OFF except strictly-necessary):
+    - strictly_necessary   (always on; app function, security)
+    - analytics            (first-party AnalyticsEvent with session_hash, GA/Umami)
+    - ads                  (AdMob/AdSense personalization)
+    - personalization      (notifications, recommendations, account linkage)
+  Actions: Accept all · Reject all (non-essential) · Customize
+```
+
+Backend `ConsentRecord` stores the granular choices, `policy_version`, timestamps. Every `AnalyticsEvent` carries a `consent_state` snapshot. Withdrawal is one tap and propagates immediately (subsequent events respect it; third-party SDKs are torn down).
+
+**Key fix vs legacy:** GA and AdSense currently load unconditionally on page load — that is non-compliant. In Azores Hub, **nothing tracking-related initializes before consent**.
+
+## 3. Retention policies (automated)
+
+Celery Beat jobs per island (default window **14 months**, configurable per `Island`):
+
+| Job | Cadence | Action |
+|-----|---------|--------|
+| `anonymize_analytics` | daily | For `AnalyticsEvent` older than retention: drop `session_hash`, strip identifying `properties`, keep only aggregate-safe fields (or roll into summary tables, then delete rows). |
+| `purge_expired_reports` | hourly | Delete expired `TrafficReport`/`FeltReport` row-level detail. |
+| `rotate_session_salt` | daily | Rotate the pseudonymization salt. |
+| `expire_consent` | daily | Re-prompt when `policy_version` changes. |
+| `purge_orphaned_media` | weekly | Remove unreferenced uploads. |
+
+Retention windows are stored as data (`Island` + a `RetentionPolicy` config), not hardcoded, so each tenant can comply with local guidance.
+
+## 4. DSAR readiness (export & erasure)
+
+The schema is built so a subject's data is findable and deletable:
+
+- Everything tied to a person links via `user` FK **or** `session_hash`.
+- Management commands / admin actions:
+  - `dsar_export <user|session_hash>` → machine-readable bundle (JSON) of all rows across modules (account, consent, reviews, events, reports, favorites, entitlements, non-anonymized analytics).
+  - `dsar_delete <user|session_hash>` → erase or anonymize across all apps in one transaction; emits an audit record (without re-introducing PII).
+- API endpoints `POST /api/v3/privacy/dsar/export` and `/delete` (authenticated; identity verification required) back self-service requests.
+- An **audit log** records DSAR fulfillment (who/when/scope) for accountability.
+
+## 5. Data governance summary
+
+| Principle | Mechanism |
+|-----------|-----------|
+| Lawful basis | Consent (analytics/ads/personalization) + legitimate interest (security, strictly-necessary) |
+| Minimization | No IP/stable-ID in analytics; session hashing; property schema validation |
+| Purpose limitation | `consent_state` snapshot per event; SDKs gated per purpose |
+| Storage limitation | Automated retention/anonymization Celery jobs |
+| Right of access/erasure | DSAR export/delete commands + endpoints + audit log |
+| Transparency | Versioned policy; CMP re-prompt on changes |
+| Cross-border | Data residency configurable per deployment (EU region) |
+
+## 6. Third-party processors
+
+GA, Umami, AdMob/AdSense, Stripe, RevenueCat, Viator, Google Maps, EMSC, dados.gov.pt — each documented in a processor register with its purpose, consent dependency, and data shared. GA/Umami/Ads are **consent-gated**; functional processors (Maps proxy, billing) operate on legitimate-interest/contract basis with minimization.

--- a/SDD/08-monetization-freemium.md
+++ b/SDD/08-monetization-freemium.md
@@ -1,0 +1,84 @@
+# SDD 08 — Freemium Monetization
+
+Three revenue mechanisms, all tenant-scoped and consent-aware: **subscriptions**, **ads (free tier)**, and **Pay-to-Promote**.
+
+## 1. Tiers
+
+| | Free | Premium |
+|--|------|---------|
+| Core features (transit, news, earthquakes, trails, marketplace, events, traffic) | ✅ | ✅ |
+| Ads | ✅ shown | ❌ removed |
+| Real-time GPS alerts (traffic/transit proximity) | ❌ | ✅ |
+| Personalized notifications | ❌ | ✅ |
+| Priority support | ❌ | ✅ |
+
+Premium = ad-free + advanced real-time + personalization. Free is fully functional, ad-supported.
+
+## 2. Subscription billing — unified `Entitlement`
+
+Two billing providers because app-store rules require IAP on mobile:
+
+| Platform | Provider |
+|----------|----------|
+| Web | **Stripe** (Checkout + Billing Portal) |
+| iOS / Android | **RevenueCat** (wraps App Store / Play Billing IAP) |
+
+Both reconcile into one `Entitlement` model ([`03-data-model.md`](./03-data-model.md) §5):
+
+```
+Stripe webhook ─────▶  Entitlement(source="stripe",     external_id=sub_id, ...)
+RevenueCat webhook ─▶  Entitlement(source="revenuecat", external_id=app_user_id, ...)
+Legacy email allow-list ▶ Entitlement(source="legacy_email", status="active")
+                                  │
+        GET /api/v3/billing/entitlement  ◀── single source of truth for "is this user premium?"
+```
+
+- The app asks the backend (not the store) "am I premium?" → consistent across platforms.
+- Webhooks update status; a periodic Celery job reconciles drift.
+- **Legacy migration:** existing `Subscription(email, is_active)` rows → `Entitlement(source="legacy_email")`, preserving current premium users with no payment data to migrate (legacy never integrated Stripe).
+- Legacy `/api/v1/subscription/verify/` keeps working via the compat shim (returns the same `{hasActiveSubscription, subscriptionType, expiresAt, features, message}` shape).
+
+Legacy reference pricing (from webapp): weekly €0.99 / monthly €1.99 / yearly €19.99 — re-validated, configured as products in Stripe/RevenueCat, not hardcoded in the client.
+
+## 3. Ads (free tier)
+
+| Ad system | Use |
+|-----------|-----|
+| **AdMob** | native (iOS/Android) banner/interstitial |
+| **AdSense** | web |
+| **First-party `Ad`** | migrated legacy campaigns (geo/route-targeted, `seen`/`clicked`, actions: open/directions/call/sms/email/whatsapp) |
+
+Rules:
+- Ads only load when `Entitlement.tier == "free"` **and** the `ads` consent purpose is granted; otherwise no ad SDK initializes.
+- First-party ads are served via `GET /api/v3/ads?slot=&platform=` (compat: `/api/v1/ad`), targeting by `StopGroup`/route, scoped to island.
+- Premium users: ad slots are removed (not just hidden) and ad SDKs never initialize.
+
+## 4. Pay-to-Promote
+
+Strictly **boost-only** monetization for Marketplace and Events. **No monthly fees, no per-job commissions.** Basic listings are 100% free.
+
+```
+Promotion
+  target_type   service_provider | community_event
+  target_id
+  status        active | scheduled | expired
+  start / end
+  tier          (e.g. featured, top-of-category)
+```
+
+- A provider/promoter buys a time-boxed boost (one-off payment via Stripe/RevenueCat).
+- Promoted items get `is_promoted=true` + ranking boost in list endpoints and a "Promoted" label (transparency).
+- Promotions expire automatically (Celery), reverting ranking.
+- Boost purchases are normal payments → tracked as `AnalyticsEvent(module, event_type="promote")`.
+
+## 5. Viator affiliate (passive income)
+
+Migrate the existing Viator integration (partner `P00222801`, campaign `sao-miguel-tours`) into the Events/Tours module:
+- `ViatorListing` + an in-app Tours surface using Viator partner widgets/deep links with affiliate params.
+- Commission is passive (Viator-side); no billing entity on our end beyond attribution tracking.
+
+## 6. Cross-cutting
+
+- Entitlement state is cached client-side per session and refreshed on launch / purchase / webhook push.
+- All monetization respects consent ([`07`](./07-gdpr-data-governance.md)) and tenancy ([`02`](./02-multi-island-whitelabel.md)).
+- Fail-safe: on entitlement-check error, default to **free/ads** (matches legacy fail-safe in the subscription integration guide).

--- a/SDD/09-modules.md
+++ b/SDD/09-modules.md
@@ -1,0 +1,96 @@
+# SDD 09 — Feature Modules
+
+Each module = one Django app (backend) + one Expo feature module (frontend). All tenant-scoped, all instrumented via `AnalyticsEvent`, all consent-aware. This doc specifies behavior and external dependencies; models are summarized in [`03-data-model.md`](./03-data-model.md).
+
+---
+
+## 1. Transit (migrated core)
+
+**Backend:** `apps/transit` — normalized `Operator/Line/Stop/Trip/StopTime/Calendar` (replaces stringified-dict `Route`).
+
+**Features (parity + improvements):**
+- Origin→destination search by day-type and start time (relational query on `StopTime`, fuzzy stop match via `pg_trgm`).
+- Step-by-step directions via server-side Google Maps proxy (`/transit/directions`).
+- Favorites (account-bound when logged in; local otherwise).
+- Likes/dislikes on trips.
+- Offline schedule cache (bootstrap payload cached client-side).
+- Operator notices / alerts (`RouteInfo`, multilingual).
+
+**Note on "real-time GPS / bus tracking":** legacy "bus tracking" is **schedule math + timers client-side**, not live operator GPS (no operator feed exists). Premium "real-time GPS alerts" therefore initially means **device-GPS proximity alerts** ("your stop is approaching", "report ahead on your route"), not live vehicle positions. Live vehicle data is a future integration gated on operator partnerships ([`12`](./12-risks-open-questions.md)).
+
+---
+
+## 2. Local News (daily utility)
+
+**Backend:** `apps/news` — `NewsSource(rss_url, language)`, `NewsArticle(title, summary, url, published_at, source, categories, image)`.
+
+**Pipeline:** Celery Beat task per source polls/parses RSS feeds from Azorean journals; dedupes by URL/hash; stores summary + canonical link (respect copyright — link out, don't republish full text); categorizes.
+
+**Frontend:** News tab — list + filters (category, source, search); deep-link to source. Search/filter/open events tracked.
+
+---
+
+## 3. Earthquakes (daily utility)
+
+**Backend:** `apps/seismic` — `SeismicEvent(emsc_id, magnitude, depth, lat, lng, occurred_at, region)`, `FeltReport(event, session_hash, lat, lng, intensity)`.
+
+**Integration:** EMSC-CSEM API (https://www.emsc-csem.org/). Celery polling task fetches recent events near `Island.center/radius_km`; upserts by `emsc_id`. Respect their rate limits — cache + incremental fetch, not per-request proxy.
+
+**Crowdsourcing:** "I felt it" → `POST /seismic/events/{id}/felt` with optional coarse location + intensity, pseudonymous `session_hash`. Aggregated felt-intensity map; premium users can get push alerts for events above a magnitude threshold near them.
+
+---
+
+## 4. Marketplace for local services
+
+**Backend:** `apps/marketplace` — `ServiceCategory`, `ServiceProvider(name, category, bio, hourly_rate, phone, geo, is_promoted, rating)`, `Review(provider, session_hash/user, rating, text)`.
+
+**Model:** directory of local tradespeople. **100% free basic listings.** Monetization is **Pay-to-Promote only** ([`08`](./08-monetization-freemium.md)) — no commissions, no monthly fees.
+
+**Features:** browse/search by category + location; provider profile (rate, contact, reviews, rating); submit review (rate-limited, moderated); contact via call/whatsapp/email. Promoted providers ranked higher with a transparent label.
+
+**Moderation:** new listings/reviews pass through a moderation queue (admin); abuse controls in [`11`](./11-security-auth.md).
+
+---
+
+## 5. Tourist Guide & Trails (open data)
+
+**Backend:** `apps/trails` — `Trail(name, difficulty, length_km, geojson, source_ref)`, `TrailStage`, `POI(name, type, geo)`.
+
+**Integration:** Portuguese Open Data API (https://dados.gov.pt/pt/) — Celery sync of official Azorean trail datasets → `Trail`/`TrailStage`, keyed by `source_ref` for idempotent updates. Attribute the open-data source per licensing.
+
+**Features:**
+- Trails browse/detail with elevation, difficulty, geojson route.
+- POIs + restaurants integrated with transit (how to reach a trailhead by bus).
+- **Offline maps** — MapLibre + cached MBTiles/vector tiles for offline trail use ([`10`](./10-frontend-architecture.md)).
+- **Micro-climate weather** — localized forecasts (Azores has sharp local variation); via a weather provider keyed by POI/trail coordinates.
+
+---
+
+## 6. Crowdsourced Traffic & Navigation (Waze-style)
+
+**Backend:** `apps/traffic` — `TrafficReport(type[radar|accident|hazard|closure], lat, lng, session_hash/user, created_at, expires_at, confirmations, status)`.
+
+**Features:**
+- User-reported alerts with location.
+- `POST /traffic/reports`; `POST /traffic/reports/{id}/confirm` (upvote) extends life; reports auto-expire (Celery).
+- **Trust model:** confirmations raise confidence; unconfirmed reports expire fast; per-session rate limits; reputation weighting ([`11`](./11-security-auth.md)).
+- **Live GPS push** (premium): alerts pushed when a user (with location + personalization consent) approaches an active report on their heading/route, via Expo Notifications.
+- `GET /traffic/reports?bbox=` for map display.
+
+---
+
+## 7. Crowdsourced Events & Tours
+
+**Backend:** `apps/events` — `CommunityEvent(title, description, start, end, venue, geo, is_promoted, status)`, `ViatorListing`.
+
+**Features:**
+- Locals submit events → moderation queue → published.
+- Promoters **Pay-to-Promote** events to the top ([`08`](./08-monetization-freemium.md)).
+- **Viator** affiliate tours surface (passive commission) integrated here.
+- Calendar/list/map views; filter by date/category; tracked.
+
+---
+
+## Module enablement
+
+Each module is gated by `Island.feature_flags` / frontend `enabledModules`, so a newly cloned island can launch transit-only and switch modules on later without code changes ([`02`](./02-multi-island-whitelabel.md)).

--- a/SDD/10-frontend-architecture.md
+++ b/SDD/10-frontend-architecture.md
@@ -1,0 +1,88 @@
+# SDD 10 — Frontend Architecture (Expo, single codebase)
+
+One Expo (React Native + Web) codebase ships Android, iOS, and Web. Replaces the legacy webapp (2.4k-line `index.html` + global JS), native Android, and Flutter clients.
+
+## 1. Stack
+
+| Concern | Choice |
+|---------|--------|
+| Framework | Expo + **Expo Router** (file-based routing, deep links, web routes) |
+| Language | TypeScript (strict) |
+| Server state | TanStack Query (cache, retries, offline) |
+| Client state | Zustand (theme, consent, session, entitlement) |
+| Styling | Theme tokens from island config; no hardcoded brand values |
+| i18n | typed i18n; port the 8 legacy locales (`pt,en,es,de,fr,it,uk,zh`) |
+| Maps | `react-native-maps` (native) + MapLibre/Leaflet (web); offline tiles via MapLibre |
+| Push | Expo Notifications |
+| Payments | Stripe web SDK + RevenueCat SDK |
+| API types | generated from backend OpenAPI (single source of truth) |
+
+## 2. Routing layout (Expo Router)
+
+```
+app/
+├── _layout.tsx            # ThemeProvider(islandConfig) + ConsentGate + QueryClient + i18n
+├── index.tsx              # redirect to default enabled module
+├── (tabs)/
+│   ├── _layout.tsx        # bottom tabs; tabs rendered per enabledModules
+│   ├── transit/           # search, results, line detail, directions, favorites
+│   ├── news/
+│   ├── earthquakes/
+│   ├── marketplace/
+│   ├── trails/
+│   ├── traffic/
+│   └── events/            # incl. Viator tours
+├── premium/               # paywall, manage subscription
+├── settings/              # language, theme, consent, account, privacy/DSAR
+└── onboarding/consent.tsx # CMP, shown first launch before any tracking
+config/
+  island.ts                # IslandConfig selected by EXPO_PUBLIC_ISLAND_KEY
+features/<module>/         # components + hooks + queries per module
+lib/                       # api client, analytics SDK, consent, theme, i18n, offline
+```
+
+Tabs and routes are **conditionally registered** from `enabledModules` so a transit-only island doesn't render empty tabs.
+
+## 3. Theming / white-label (see [`02`](./02-multi-island-whitelabel.md))
+
+- `ThemeProvider` consumes `IslandConfig` (colors, logos, fonts) at the root.
+- Components reference `theme.primary`/`theme.secondary`/etc., never literals.
+- `EXPO_PUBLIC_ISLAND_KEY` selects the config + asset bundle at build (EAS profile per island).
+- Dark/light support (legacy had a theme toggle) via token sets.
+
+## 4. Consent gate (CMP)
+
+- `ConsentGate` wraps the app; on first launch (or policy change) it shows `onboarding/consent.tsx` **before** initializing GA/Umami/AdMob/AdSense or sending any `AnalyticsEvent`.
+- Consent stored locally + synced to backend `ConsentRecord`.
+- Analytics/Ads SDKs are lazy-initialized only for granted purposes and torn down on withdrawal.
+- Settings has a "Privacy" screen for re-consent, data export, and deletion (DSAR — [`07`](./07-gdpr-data-governance.md)).
+
+## 5. Configuration (fixes legacy hardcoding)
+
+- `EXPO_PUBLIC_API_URL` — API base (legacy hardcoded `https://api.saomiguelbus.com`; **must** be env-driven so dev/staging/prod and local work).
+- `EXPO_PUBLIC_ISLAND_KEY` — active tenant.
+- All requests send `X-Island` header.
+- **No secrets in client** — Google Maps key and proxy `AUTH_KEY` stay server-side (legacy leaks both in client source — [`11`](./11-security-auth.md)).
+
+## 6. Offline strategy
+
+- Transit schedule + trails + last news cached via TanStack Query persistence + AsyncStorage (replaces legacy `localStorage.apiData`).
+- Offline map tiles (MapLibre MBTiles) for trails/traffic.
+- Graceful degradation: features needing network (live directions, submitting reports) disable cleanly offline (legacy already hides directions offline).
+- PWA: web target keeps installability + service worker (cleaner than the legacy SW that referenced a non-existent `agentHandler.js`).
+
+## 7. Analytics SDK (client side, see [`06`](./06-analytics-tracking.md))
+
+`track(module, eventType, properties)` — consent-gated, batched, PII-stripped, mirrors to GA/Umami only with consent.
+
+## 8. Migration notes from legacy frontend
+
+| Legacy | New |
+|--------|-----|
+| Show/hide `<section class="page">` | Expo Router screens |
+| Global functions + `innerHTML` | React components + hooks |
+| Cookies/`localStorage` ad-hoc state | Zustand + persisted Query cache |
+| Hardcoded API URL | `EXPO_PUBLIC_API_URL` |
+| Tailwind CDN, no build | RN styling/theme tokens, EAS builds |
+| Three clients (web/Android/Flutter) | one Expo codebase |
+| 8 JSON locales | ported to typed i18n (keep keys, run `check_locale_keys` equivalent) |

--- a/SDD/11-security-auth.md
+++ b/SDD/11-security-auth.md
@@ -1,0 +1,66 @@
+# SDD 11 — Security, Auth & Trust
+
+## 1. Identity model
+
+| Actor | Mechanism |
+|-------|-----------|
+| Anonymous reader | No auth; read-only public endpoints; pseudonymous `session_hash` for analytics/votes |
+| Registered user | djast custom `User` + DRF token/JWT; required for account-bound favorites, reviews, event submissions, DSAR |
+| Admin / operator | Django admin + role-based permissions; schedule/ad/moderation management |
+| Service (Celery, webhooks) | Signed webhook secrets (Stripe/RevenueCat), internal task auth |
+
+Anonymous-first stays true to the legacy public API, but **writes** that affect community trust require either an account or a signed anonymous session token.
+
+## 2. Secrets — fixing legacy leaks
+
+Legacy ships secrets to clients:
+- Google Maps proxy key `AUTH_KEY` is **in client JS** (`...&key=SMBFj56xBCLc986j6odk3AK6fJa95k`).
+- The Google Maps API key flows through the proxy but the proxy access key is exposed.
+- A 128-char subscription-creation secret + a hardcoded `reset/likes` key exist server-side.
+
+Azores Hub:
+- **No third-party keys in the client.** Maps directions stay behind the server proxy; clients call `/transit/directions` with their normal session, not a shared static key.
+- Secrets via environment/secret manager (djast convention), never committed, never shipped.
+- Remove hardcoded admin "magic" keys; replace with proper admin auth + signed/permissioned endpoints.
+
+## 3. Tenancy isolation
+
+- Active island resolved server-side from `X-Island`/subdomain; **never** trusted from request body.
+- `TenantManager` enforces island filtering at the ORM layer so a bug in a view can't leak another island's data.
+- Cross-tenant access only via explicit admin/Celery `for_island()`.
+
+## 4. Crowdsourcing trust & abuse (traffic, reviews, events, felt reports)
+
+| Risk | Control |
+|------|---------|
+| Spam / fake reports | Per-`session_hash`/IP-bucket rate limits (DRF throttles); CAPTCHA/app-attestation on suspicious volume |
+| Vote manipulation (likes, confirmations) | One vote per session per target; confirmation decay; reputation weighting |
+| Abusive content (reviews/events) | Moderation queue; profanity/PII filters; report-content flow |
+| Stale/false alerts | Auto-expiry + confirmation-based confidence |
+| Location spoofing | Plausibility checks (within island radius; speed/heading sanity) |
+
+## 5. Transport & platform security
+
+- HTTPS everywhere; HSTS.
+- CORS scoped to known origins (legacy uses `CORS_ALLOW_ALL_ORIGINS=True` — tighten).
+- CSRF: token auth for API; proper CSRF for any session-cookie surfaces.
+- Input validation via DRF serializers + property-schema registry for analytics.
+- Webhook signature verification (Stripe/RevenueCat).
+- Rate limiting + WAF at the edge.
+
+## 6. Privacy-security overlap
+
+- Pseudonymization secret + rotating salt stored in secret manager ([`07`](./07-gdpr-data-governance.md)).
+- DSAR endpoints require strong identity verification before export/delete.
+- Audit logs for admin/DSAR actions (no PII re-introduced).
+
+## 7. Threat model summary
+
+| Threat | Mitigation |
+|--------|------------|
+| Tenant data leakage | ORM-level tenant scoping, server-resolved island |
+| Key/secret theft from client | No secrets in client; server-side proxy |
+| Analytics re-identification | Rotating-salt session hashing, no IP/stable-ID |
+| Crowdsourcing abuse | Rate limits, moderation, reputation, expiry |
+| Payment fraud / entitlement spoofing | Server is source of truth; webhook verification; reconciliation job |
+| Mass scraping | Throttling, pagination, caching |

--- a/SDD/12-risks-open-questions.md
+++ b/SDD/12-risks-open-questions.md
@@ -1,0 +1,53 @@
+# SDD 12 — Risks, Assumptions & Open Questions
+
+Resolve or accept these **before Phase 1 coding**.
+
+## 1. Assumptions to confirm
+
+| # | Assumption | Impact if wrong |
+|---|------------|-----------------|
+| A1 | `djast` provides project scaffold, settings split, DRF/CORS, Celery/Redis, custom `User`, secret loading. | If it lacks Celery/auth, Phase 1/2 scope grows. |
+| A2 | New code lives in `sao-miguel-hub`; these docs move there on approval (committed to legacy `SaoMiguelBus` repo only because the new repo isn't in this workspace yet). | Repo provisioning is a Phase 0 task. |
+| A3 | Legacy production Postgres is accessible (read replica/dump) for ETL. | Without it, only `data.json` + `scripts/` seed data available — partial history. |
+| A4 | EMSC-CSEM, dados.gov.pt, Viator, Google Maps remain available under current terms/limits. | Feed-dependent modules (earthquakes, trails, tours, directions) at risk. |
+| A5 | Reusing GA (`G-YSWK1F7F0B`) + self-hosted Umami is desired, now consent-gated. | May choose to drop one to simplify. |
+
+## 2. Open questions (need product/stakeholder decision)
+
+1. **Mobile distribution:** keep the existing Play Store listing (`com.hsousa_apps.Autocarros`) and update it to the Expo build, or publish a new app? Affects store continuity, reviews, install base.
+2. **Multi-tenant vs single-tenant deploy:** one backend serving many islands, or one deployment per island? Schema supports both; ops/cost/isolation tradeoff.
+3. **"Real-time GPS alerts" definition:** confirmed there is **no live operator vehicle feed** today (legacy tracking is schedule math). Is device-GPS proximity alerting an acceptable v1 for the premium feature, with live vehicle data deferred until operator partnerships exist?
+4. **Retention window:** 14 months proposed as default — confirm per legal guidance; per-island override needed?
+5. **News scraping legality:** confirm RSS terms for each Azorean journal; link-out + summary only (no full-text republish) acceptable?
+6. **Consent default for existing users:** migrated users are pre-CMP. Re-prompt all on first launch of new app (proposed) vs treat legacy analytics as aggregate-only?
+7. **Pricing:** reuse legacy €0.99/€1.99/€19.99, or re-model for the expanded multi-module product?
+8. **Reviews/UGC identity:** allow anonymous reviews (session-based) or require account? Affects abuse + DSAR.
+9. **Offline map tiles:** licensing/source for MBTiles (OSM-based) and storage budget per island.
+10. **Desktop web experience:** retire the legacy `desktop/` variant in favor of responsive Expo Web, or preserve a distinct desktop layout?
+
+## 3. Technical risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `Route.stops` stringified-dict parsing edge cases (malformed entries, duplicate stop names, odd time formats) | High | Robust `ast.literal_eval` ETL with per-row error logging + manual-review queue; parity validation gate ([`05`](./05-data-migration.md)) |
+| Unmatched/duplicate stop names breaking FK resolution | Medium | Trigram fuzzy match + coordinate backfill + flagged review list |
+| Search-result parity regressions vs legacy | Medium | Recorded request/response matrix diffed pre-cutover |
+| Client cutover breaking in-the-wild apps | Medium | Compat shim preserving v1/v2 shapes; strangler-fig with legacy fallback |
+| External feed rate limits / outages (EMSC, dados.gov.pt, RSS) | Medium | Cached Celery sync, backoff, stale-while-revalidate |
+| App-store IAP rules vs Stripe-on-web mismatch | Medium | RevenueCat for mobile, Stripe for web, unified `Entitlement` |
+| Crowdsourcing abuse at launch | Medium | Rate limits, moderation, reputation, expiry ([`11`](./11-security-auth.md)) |
+| Analytics table volume (append-only) | Medium | Partitioning + aggregate rollups + retention purge ([`06`](./06-analytics-tracking.md),[`07`](./07-gdpr-data-governance.md)) |
+| Scope creep across 7 modules | High | Phased plan; modules gated by `feature_flags`; transit-first parity before new modules |
+
+## 4. Explicitly deferred
+
+- Live operator vehicle GPS (needs partnerships).
+- Non-Azores regions (architecture supports, not in initial scope).
+- Replacing Google Maps as directions provider.
+- ML/personalized recommendations beyond basic personalization.
+
+## 5. Decision log (to be filled during review)
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| _TBD_ | _awaiting approval of this SDD_ | — |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Software Design Document (SDD) + phased migration plan to evolve **São Miguel Bus** into the multi-island **Azores Hub** platform (first instance `sao-miguel-hub`). **Documentation only — no implementation code.** Awaiting approval before coding.

Adds:
- `MIGRATION_PLAN.md` (root) — executive index, target architecture, guiding principles, and the 5-phase plan (Phase 0–5) with exit criteria + reversible strangler-fig cutover.
- `SDD/` — 13 detailed design docs.

## SDD contents

| Doc | Focus |
|-----|-------|
| `00-overview` | Vision, scope, personas, success metrics, glossary |
| `01-architecture` | Modular-monolith Django (`djast`) + Expo (RN+Web), tech stack, repo layout, envs |
| `02-multi-island-whitelabel` | `Island`/`Hub` tenant root, ORM-level scoping, frontend theming config |
| `03-data-model` | Normalized transit schema (GTFS-style) + full legacy→new field mapping |
| `04-api-design` | DRF ViewSets, `/api/v3`, legacy `/v1`+`/v2` compatibility shim |
| `05-data-migration` | ETL for 2020+ data, parsing the stringified-dict `Route.stops`, parity gate |
| `06-analytics-tracking` | Universal `AnalyticsEvent` spine across all 7 modules |
| `07-gdpr-data-governance` | CMP, session pseudonymization, retention jobs, DSAR |
| `08-monetization-freemium` | Stripe + RevenueCat unified `Entitlement`, ads, Pay-to-Promote |
| `09-modules` | Transit, News, Earthquakes, Marketplace, Trails, Traffic, Events/Viator |
| `10-frontend-architecture` | Expo Router layout, theming, consent gate, offline, config |
| `11-security-auth` | Identity, secret-leak fixes, tenant isolation, crowdsourcing trust |
| `12-risks-open-questions` | Assumptions, decisions needed, technical risks |

## Key architectural decisions

- **Tenant-first:** every domain row scoped to `Island`; new islands are config + data, not forks.
- **One codebase:** Expo replaces webapp + native Android + Flutter; API base + secrets no longer hardcoded/leaked client-side.
- **Normalize transit:** replace fragile stringified-dict schedules with relational `Line/Trip/StopTime/Stop/Calendar`.
- **Privacy by design:** consent before any tracking, rotating-salt session hashing, automated 14-month retention, DSAR commands.
- **Reversible cutover:** compat shim preserves legacy `/v1`+`/v2` shapes so in-the-wild clients keep working.

## Notes

- Placed in the `SaoMiguelBus` repo because the target `sao-miguel-hub` repo doesn't yet exist in this workspace; on approval these move to `sao-miguel-hub/SDD/`.
- No code, components, or API views written per the explicit constraint.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-851a28be-d0e1-47e1-b8f2-ee797c355fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-851a28be-d0e1-47e1-b8f2-ee797c355fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

