### PR TITLE
feat: transit first-party ads + premium gating (tracking/pins)

### DIFF
--- a/app/(tabs)/transit/index.tsx
+++ b/app/(tabs)/transit/index.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import React, { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -9,6 +10,7 @@ import { space } from '@/lib/tokens';
 import { Bus } from 'lucide-react-native';
 
 import { Banner } from '@/components/ui/Banner';
+import { AdBanner } from '@/features/ads/components/AdBanner';
 import { ActiveTrackingSection } from '@/features/transit/components/ActiveTrackingSection';
 import { PinnedRoutesSection } from '@/features/transit/components/PinnedRoutesSection';
 import { RouteResults } from '@/features/transit/components/RouteResults';
@@ -42,6 +44,7 @@ export default function TransitScreen() {
   const theme = useAppTheme();
   const { t } = useTranslation();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const params = useLocalSearchParams<{ origin?: string; destination?: string }>();
   const { isOnline, isPremium } = useNetwork();
   const canSearchOffline = useCanSearchOffline();
@@ -100,6 +103,8 @@ export default function TransitScreen() {
     }
     setSearchEnabled(true);
     search.refetch();
+    // Rotate the top banner on each new search (webapp re-calls loadAdBanner).
+    void queryClient.invalidateQueries({ queryKey: ['ad', 'home'] });
   };
 
   const openDirections = () => {
@@ -181,6 +186,8 @@ export default function TransitScreen() {
               onAction={isOnline ? openDirections : undefined}
             />
           ) : null}
+
+          {hasResults ? <AdBanner on="home" slot="top" /> : null}
 
           {hasResults && search.data ? (
             <RouteResults

--- a/features/ads/components/AdBanner.tsx
+++ b/features/ads/components/AdBanner.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { useAd } from '@/features/ads/hooks/useAd';
+import { track } from '@/lib/analytics';
+import { radius, space, typography } from '@/lib/tokens';
+import { useAppTheme } from '@/lib/theme';
+
+type Props = {
+  /** Compat slot: `home` for search surfaces, `routes` for directions. */
+  on: string;
+  /** Distinguishes multiple banners on the same surface (separate rotation). */
+  slot?: string | number;
+};
+
+/**
+ * First-party SMB banner: image + outbound link only. No dismiss control, no
+ * subscribe CTA, no interstitial. Renders nothing for premium users, offline,
+ * or when no ad is available — so it never reserves layout space.
+ */
+export function AdBanner({ on, slot }: Props) {
+  const theme = useAppTheme();
+  const { t } = useTranslation();
+  const { ad, openAd } = useAd(on, slot);
+  const [aspectRatio, setAspectRatio] = useState(4);
+
+  useEffect(() => {
+    if (!ad?.media) {
+      return;
+    }
+    let cancelled = false;
+    Image.getSize(
+      ad.media,
+      (width, height) => {
+        if (!cancelled && width > 0 && height > 0) {
+          setAspectRatio(width / height);
+        }
+      },
+      () => {},
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [ad?.media]);
+
+  useEffect(() => {
+    if (ad?.id != null) {
+      track('transit', 'ad_impression', { on, adId: ad.id });
+    }
+  }, [ad?.id, on]);
+
+  if (!ad) {
+    return null;
+  }
+
+  return (
+    <Pressable
+      onPress={openAd}
+      accessibilityRole="link"
+      accessibilityLabel={ad.entity || t('transitAdLabel')}
+      accessibilityHint={t('transitAdAccessibilityHint')}
+      style={[styles.wrap, { borderColor: theme.border, backgroundColor: theme.card }]}
+    >
+      <View style={[styles.badge, { backgroundColor: theme.primary }]}>
+        <Text style={[styles.badgeText, { color: theme.onPrimary }]}>{t('transitAdLabel')}</Text>
+      </View>
+      <Image
+        source={{ uri: ad.media }}
+        style={[styles.image, { aspectRatio }]}
+        resizeMode="cover"
+        accessibilityIgnoresInvertColors
+      />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    width: '100%',
+    borderRadius: radius.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  badge: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    zIndex: 10,
+    paddingHorizontal: space.xs,
+    paddingVertical: 2,
+    borderBottomRightRadius: radius.sm,
+  },
+  badgeText: { ...typography.overline, fontSize: 9, letterSpacing: 0.8 },
+  image: { width: '100%' },
+});

--- a/features/ads/hooks/useAd.ts
+++ b/features/ads/hooks/useAd.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { Linking } from 'react-native';
+
+import { resolveAdHref } from '@/features/ads/lib/ad-link';
+import { track } from '@/lib/analytics';
+import { fetchAd, recordAdClick } from '@/lib/api';
+import { canShowFirstPartyAds } from '@/lib/consent-store';
+import { logger } from '@/lib/logger';
+import { useNetwork } from '@/lib/network-provider';
+import { getAnalyticsPlatform } from '@/lib/platform';
+import { usePremium } from '@/lib/premium-store';
+import type { AdPayload } from '@/lib/types';
+
+/**
+ * Fetch a single first-party ad for a slot and expose a tap handler.
+ *
+ * Suppressed (no network call) for premium users and while offline. Each slot
+ * gets its own query key so multiple banners on the same surface rotate
+ * independently, mirroring the webapp's per-slot fetch.
+ */
+export function useAd(on: string, slot: string | number = 'top') {
+  const isPremium = usePremium();
+  const { isOnline } = useNetwork();
+  const platform = getAnalyticsPlatform();
+  const enabled = canShowFirstPartyAds(isPremium) && isOnline;
+
+  const query = useQuery<AdPayload | null>({
+    queryKey: ['ad', on, platform, slot],
+    queryFn: () => fetchAd({ on, platform }),
+    enabled,
+    staleTime: 1000 * 60,
+    retry: false,
+  });
+
+  const ad = query.data ?? null;
+
+  const openAd = useCallback(async () => {
+    if (!ad) {
+      return;
+    }
+    track('transit', 'ad_click', { on, adId: ad.id });
+    void recordAdClick(ad.id);
+    const href = resolveAdHref(ad);
+    if (!href) {
+      return;
+    }
+    try {
+      await Linking.openURL(href);
+    } catch (error) {
+      logger.warn('ad open failed', error);
+    }
+  }, [ad, on]);
+
+  return { ad, openAd, enabled };
+}

--- a/features/ads/lib/ad-link.ts
+++ b/features/ads/lib/ad-link.ts
@@ -1,0 +1,16 @@
+import type { AdPayload } from '@/lib/types';
+
+/**
+ * Resolve the outbound href for an ad. Mirrors the legacy webapp: when
+ * `action === 'directions'`, `target` is a place name opened in Google Maps;
+ * otherwise `target` is a plain URL. Returns `null` when there is nowhere to go.
+ */
+export function resolveAdHref(ad: AdPayload): string | null {
+  if (!ad.target) {
+    return null;
+  }
+  if (ad.action === 'directions') {
+    return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(ad.target)}`;
+  }
+  return ad.target;
+}

--- a/features/premium/hooks/usePremiumGate.ts
+++ b/features/premium/hooks/usePremiumGate.ts
@@ -1,0 +1,40 @@
+import { useRouter } from 'expo-router';
+import { useCallback } from 'react';
+
+import { usePaywall } from '@/features/premium/hooks/usePaywall';
+import { setPendingPaywall } from '@/features/premium/lib/paywall-intent';
+import { useAuthStore } from '@/lib/auth-store';
+import { usePremium } from '@/lib/premium-store';
+
+/**
+ * Shared seam for premium-gated actions (tracking, pinning, …).
+ *
+ * - Premium → run the action immediately.
+ * - Signed-out free → defer a paywall and route to sign-in; the sign-in screen
+ *   resumes into the paywall on success (see `consumePendingPaywall`).
+ * - Signed-in free → present the RevenueCat paywall (`presentIfNeeded`).
+ */
+export function usePremiumGate() {
+  const isPremium = usePremium();
+  const isSignedIn = useAuthStore((s) => Boolean(s.token));
+  const router = useRouter();
+  const { presentIfNeeded } = usePaywall();
+
+  const guardPremiumAction = useCallback(
+    async (action: () => void) => {
+      if (isPremium) {
+        action();
+        return;
+      }
+      if (!isSignedIn) {
+        setPendingPaywall(true);
+        router.push('/auth/sign-in');
+        return;
+      }
+      await presentIfNeeded();
+    },
+    [isPremium, isSignedIn, presentIfNeeded, router],
+  );
+
+  return { isPremium, guardPremiumAction };
+}

--- a/features/transit/components/ActiveTrackingSection.tsx
+++ b/features/transit/components/ActiveTrackingSection.tsx
@@ -6,15 +6,18 @@ import { useTranslation } from 'react-i18next';
 import { IconButton } from '@/components/ui/IconButton';
 import { TransitCollapsibleSection } from '@/features/transit/components/TransitCollapsibleSection';
 import { useBusTracking } from '@/features/transit/hooks/useBusTracking';
+import { usePremium } from '@/lib/premium-store';
 import { space, typography } from '@/lib/tokens';
 import { useAppTheme } from '@/lib/theme';
 
 export function ActiveTrackingSection() {
   const theme = useAppTheme();
   const { t } = useTranslation();
+  const isPremium = usePremium();
   const { active, stopTracking } = useBusTracking();
 
-  if (active.length === 0) {
+  // Webapp parity: the active-tracking widget is premium-only.
+  if (!isPremium || active.length === 0) {
     return null;
   }
 

--- a/features/transit/components/DirectionsResults.tsx
+++ b/features/transit/components/DirectionsResults.tsx
@@ -1,9 +1,10 @@
 import { Bus, ChevronDown, ChevronUp, Footprints, MapPin, Shuffle } from 'lucide-react-native';
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import { Card } from '@/components/ui/Card';
+import { AdBanner } from '@/features/ads/components/AdBanner';
 import { RouteMap } from '@/features/transit/components/RouteMap';
 import { iconSize, space, typography } from '@/lib/tokens';
 import { useAppTheme } from '@/lib/theme';
@@ -201,11 +202,19 @@ export function DirectionsResults({ data, origin, destination }: Props) {
     );
   }
 
+  const routes = data.routes;
   return (
     <View style={styles.list}>
-      {data.routes.map((route, routeIndex) => (
-        <RouteDirectionCard key={`route-${routeIndex}`} route={route} index={routeIndex} />
-      ))}
+      {routes.map((route, routeIndex) => {
+        // Webapp parity: inline ad after every 2 routes (never after the last).
+        const showInlineAd = (routeIndex + 1) % 2 === 0 && routeIndex < routes.length - 1;
+        return (
+          <Fragment key={`route-${routeIndex}`}>
+            <RouteDirectionCard route={route} index={routeIndex} />
+            {showInlineAd ? <AdBanner on="routes" slot={`inline-${routeIndex}`} /> : null}
+          </Fragment>
+        );
+      })}
     </View>
   );
 }

--- a/features/transit/components/PinnedRoutesSection.tsx
+++ b/features/transit/components/PinnedRoutesSection.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { IconButton } from '@/components/ui/IconButton';
 import { TransitCollapsibleSection } from '@/features/transit/components/TransitCollapsibleSection';
 import { useBusTracking } from '@/features/transit/hooks/useBusTracking';
+import { usePremium } from '@/lib/premium-store';
 import { space, typography } from '@/lib/tokens';
 import { useAppTheme } from '@/lib/theme';
 
@@ -16,9 +17,11 @@ type Props = {
 export function PinnedRoutesSection({ onSelect }: Props) {
   const theme = useAppTheme();
   const { t } = useTranslation();
+  const isPremium = usePremium();
   const { pinned, unpinRoute } = useBusTracking();
 
-  if (pinned.length === 0) {
+  // Webapp parity: pinned routes are a premium-only widget.
+  if (!isPremium || pinned.length === 0) {
     return null;
   }
 

--- a/features/transit/components/RouteResults.tsx
+++ b/features/transit/components/RouteResults.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 
+import { AdBanner } from '@/features/ads/components/AdBanner';
 import { FavoritesPanel } from '@/features/transit/components/FavoritesPanel';
 import { RouteCard } from '@/features/transit/components/RouteCard';
 import { RouteResultsToolbar } from '@/features/transit/components/RouteResultsToolbar';
@@ -30,9 +31,17 @@ export function RouteResults({ results, searchDay, origin, destination, onFavori
         onShowFavorites={() => setShowFavorites(true)}
       />
       {showFavorites ? <FavoritesPanel onSelect={onFavoriteSelect} /> : null}
-      {results.map((trip) => (
-        <RouteCard key={trip.id} trip={trip} searchDay={searchDay} />
-      ))}
+      {results.map((trip, index) => {
+        // Mirror the webapp: insert an inline ad after every 2 result cards
+        // (never after the last one). Premium/offline users render nothing.
+        const showInlineAd = (index + 1) % 2 === 0 && index < results.length - 1;
+        return (
+          <Fragment key={trip.id}>
+            <RouteCard trip={trip} searchDay={searchDay} />
+            {showInlineAd ? <AdBanner on="home" slot={`inline-${index}`} /> : null}
+          </Fragment>
+        );
+      })}
     </View>
   );
 }

--- a/features/transit/components/TrackButton.tsx
+++ b/features/transit/components/TrackButton.tsx
@@ -3,6 +3,7 @@ import { Alert, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import { IconButton } from '@/components/ui/IconButton';
+import { usePremiumGate } from '@/features/premium/hooks/usePremiumGate';
 import { useBusTracking } from '@/features/transit/hooks/useBusTracking';
 import { useProfileStore } from '@/lib/profile-store';
 import { space } from '@/lib/tokens';
@@ -19,6 +20,7 @@ export function TrackButton({ trip, searchDay, showPin = true }: Props) {
   const theme = useAppTheme();
   const { t } = useTranslation();
   const { canStartMore, startFromTrip, stopTracking, pinFromTrip, isTrackingTrip } = useBusTracking();
+  const { guardPremiumAction } = usePremiumGate();
   const active = useProfileStore((s) => s.tracking.active);
   const tracking = isTrackingTrip(trip.id, trip.origin, trip.destination);
   const activeId = active.find(
@@ -26,18 +28,25 @@ export function TrackButton({ trip, searchDay, showPin = true }: Props) {
   )?.id;
 
   const onTrack = () => {
+    // Stopping an active track is always allowed; starting is premium-gated.
     if (tracking && activeId) {
       stopTracking(activeId);
       return;
     }
-    if (!canStartMore) {
-      Alert.alert(t('transitTrackCapTitle'), t('transitTrackCapMessage'));
-      return;
-    }
-    const ok = startFromTrip(trip, searchDay);
-    if (!ok) {
-      Alert.alert(t('transitTrackCapTitle'), t('transitTrackCapMessage'));
-    }
+    void guardPremiumAction(() => {
+      if (!canStartMore) {
+        Alert.alert(t('transitTrackCapTitle'), t('transitTrackCapMessage'));
+        return;
+      }
+      const ok = startFromTrip(trip, searchDay);
+      if (!ok) {
+        Alert.alert(t('transitTrackCapTitle'), t('transitTrackCapMessage'));
+      }
+    });
+  };
+
+  const onPin = () => {
+    void guardPremiumAction(() => pinFromTrip(trip, searchDay));
   };
 
   return (
@@ -55,7 +64,7 @@ export function TrackButton({ trip, searchDay, showPin = true }: Props) {
           variant="tonal"
           color={theme.accent}
           accessibilityLabel={t('transitPinRoute')}
-          onPress={() => pinFromTrip(trip, searchDay)}
+          onPress={onPin}
         />
       ) : null}
     </View>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -5,6 +5,7 @@ import { logger } from '@/lib/logger';
 import { getAnalyticsPlatform, getAppVersion } from '@/lib/platform';
 import { getOrCreateSessionId } from '@/lib/session';
 import type {
+  AdPayload,
   AuthResponse,
   AuthUser,
   Entitlement,
@@ -88,6 +89,38 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
 
 export function getApiBase(): string {
   return API_BASE;
+}
+
+// --- First-party ads (compat /api/v1/ad) --- //
+
+/**
+ * Fetch a first-party ad for a slot. Compat returns 404 when no ad is eligible;
+ * we resolve `null` rather than throwing so callers render nothing (no error UI).
+ */
+export async function fetchAd(params: { on: string; platform: string }): Promise<AdPayload | null> {
+  const query = new URLSearchParams({ on: params.on, platform: params.platform });
+  const url = `${API_BASE}/api/v1/ad?${query.toString()}`;
+  try {
+    const response = await fetch(url, { headers: islandHeaders() });
+    if (!response.ok) {
+      // 404 (empty inventory) and any other non-2xx → no ad, no error UI.
+      return null;
+    }
+    return (await response.json()) as AdPayload;
+  } catch (error) {
+    logger.warn('ad fetch failed', error);
+    return null;
+  }
+}
+
+/** Fire-and-forget ad click counter. Never throws. */
+export async function recordAdClick(id: number): Promise<void> {
+  const url = `${API_BASE}/api/v1/ad/click?id=${encodeURIComponent(String(id))}`;
+  try {
+    await fetch(url, { method: 'POST', headers: islandHeaders() });
+  } catch (error) {
+    logger.warn('ad click failed', error);
+  }
 }
 
 // --- Accounts & premium entitlement --- //

--- a/lib/consent-store.ts
+++ b/lib/consent-store.ts
@@ -48,6 +48,25 @@ function persistDecision(
   });
 }
 
+/**
+ * First-party SMB banners (compat `/api/v1/ad`) are intentionally NOT gated on
+ * `purposes.ads`. They are shown to every non-premium user, matching the legacy
+ * webapp. The `ads` purpose is reserved for future third-party ad SDKs
+ * (AdMob/AdSense) — see `canShowExternalAds()`.
+ */
+export function canShowFirstPartyAds(isPremium: boolean): boolean {
+  return !isPremium;
+}
+
+/**
+ * Consent gate for FUTURE third-party ad SDKs only. First-party banners must
+ * never call this — use `canShowFirstPartyAds()` instead.
+ */
+export function canShowExternalAds(): boolean {
+  const { decided, purposes } = useConsentStore.getState();
+  return decided && purposes.ads;
+}
+
 export const useConsentStore = create<ConsentState>()(
   persist(
     (set, get) => ({

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -394,6 +394,29 @@ export interface WeatherParishesResponse {
   attribution: string;
 }
 
+// --- First-party ads (compat /api/v1/ad) --- //
+
+/**
+ * First-party SMB ad payload, shaped exactly as compat `GET /api/v1/ad` returns
+ * it (snake_case fields preserved). `action === 'directions'` means `target` is
+ * a place name to open in Maps; otherwise `target` is a plain URL.
+ */
+export interface AdPayload {
+  id: number;
+  entity: string;
+  description: string;
+  media: string;
+  start: string | null;
+  end: string | null;
+  action: string | null;
+  target: string | null;
+  advertise_on?: string;
+  platform?: string;
+  status?: string;
+  seen?: number;
+  clicked?: number;
+}
+
 // --- Accounts & premium entitlement --- //
 
 export type SocialProvider = 'apple' | 'google';

--- a/locales/de.json
+++ b/locales/de.json
@@ -92,6 +92,8 @@
     "advertiseSubtitle": "Werben Sie Ihr Geschäft für Einwohner und Touristen auf São Miguel Bus.",
     "adBannerTitle": "WERBEN SIE HIER",
     "adBannerSubtitle": "Erfahren Sie mehr unter ad.saomiguelbus.com",
+    "transitAdLabel": "Werbung",
+    "transitAdAccessibilityHint": "Öffnet den Link des Werbetreibenden",
     "advertisingOpportunity": "Werbemöglichkeit",
     "advertisingOpportunityDescription": "Werben Sie Ihr Geschäft für Einwohner und Touristen auf São Miguel Bus.",
     "exactTargeting": "Präzises Targeting",

--- a/locales/en.json
+++ b/locales/en.json
@@ -223,6 +223,8 @@
     "advertiseSubtitle": "Advertise your business for residents and tourists on São Miguel Bus.",
     "adBannerTitle": "ADVERTISE HERE",
     "adBannerSubtitle": "Learn more at ad.saomiguelbus.com",
+    "transitAdLabel": "Ad",
+    "transitAdAccessibilityHint": "Opens the advertiser's link",
     "advertisingOpportunity": "Advertising Opportunity",
     "advertisingOpportunityDescription": "Advertise your business for residents and tourists on São Miguel Bus.",
     "exactTargeting": "Exact Targeting",

--- a/locales/es.json
+++ b/locales/es.json
@@ -92,6 +92,8 @@
     "advertiseSubtitle": "Anuncie su negocio para residentes y turistas de la isla de São Miguel.",
     "adBannerTitle": "ANUNCIE AQUÍ",
     "adBannerSubtitle": "Más información en ad.saomiguelbus.com",
+    "transitAdLabel": "Anuncio",
+    "transitAdAccessibilityHint": "Abre el enlace del anunciante",
     "advertisingOpportunity": "Oportunidad de Publicidad",
     "advertisingOpportunityDescription": "Anuncie su negocio para residentes y turistas de la isla de São Miguel.",
     "exactTargeting": "Segmentación Precisa",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -92,6 +92,8 @@
     "advertiseSubtitle": "Vous pouvez annoncer votre entreprise aux résidents et touristes de l'île de São Miguel.",
     "adBannerTitle": "ANNONCEZ ICI",
     "adBannerSubtitle": "Plus d'informations sur ad.saomiguelbus.com",
+    "transitAdLabel": "Annonce",
+    "transitAdAccessibilityHint": "Ouvre le lien de l'annonceur",
     "advertisingOpportunity": "Opportunité de Publicité",
     "advertisingOpportunityDescription": "Vous pouvez annoncer votre entreprise aux résidents et touristes de l'île de São Miguel.",
     "exactTargeting": "Ciblage Précis",

--- a/locales/it.json
+++ b/locales/it.json
@@ -92,6 +92,8 @@
     "advertiseSubtitle": "Pubblicizza la tua attività per residenti e turisti su São Miguel Bus.",
     "adBannerTitle": "PUBBLICIZZA QUI",
     "adBannerSubtitle": "Scopri di più su ad.saomiguelbus.com",
+    "transitAdLabel": "Annuncio",
+    "transitAdAccessibilityHint": "Apre il link dell'inserzionista",
     "advertisingOpportunity": "Opportunità Pubblicitaria",
     "advertisingOpportunityDescription": "Pubblicizza la tua attività per residenti e turisti su São Miguel Bus.",
     "exactTargeting": "Targeting Preciso",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -223,6 +223,8 @@
     "advertiseSubtitle": "Anuncie o seu negócio para residentes e turistas da ilha de São Miguel.",
     "adBannerTitle": "ANUNCIE AQUI",
     "adBannerSubtitle": "Saiba mais em ad.saomiguelbus.com",
+    "transitAdLabel": "Anúncio",
+    "transitAdAccessibilityHint": "Abre a ligação do anunciante",
     "advertisingOpportunity": "Oportunidade de Publicidade",
     "advertisingOpportunityDescription": "Anuncie o seu negócio para residentes e turistas da ilha de São Miguel.",
     "exactTargeting": "Segmentação Precisa",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -92,6 +92,8 @@
     "advertiseSubtitle": "Рекламуйте свій бізнес для жителів і туристів на São Miguel Bus.",
     "adBannerTitle": "РЕКЛАМУЙТЕСЯ ТУТ",
     "adBannerSubtitle": "Дізнайтеся більше на ad.saomiguelbus.com",
+    "transitAdLabel": "Реклама",
+    "transitAdAccessibilityHint": "Відкриває посилання рекламодавця",
     "advertisingOpportunity": "Рекламна Можливість",
     "advertisingOpportunityDescription": "Рекламуйте свій бізнес для жителів і туристів на São Miguel Bus.",
     "exactTargeting": "Точне Таргетування",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -92,6 +92,8 @@
     "advertiseSubtitle": "为圣米格尔巴士的居民和游客宣传您的业务。",
     "adBannerTitle": "在此做广告",
     "adBannerSubtitle": "了解更多请访问 ad.saomiguelbus.com",
+    "transitAdLabel": "广告",
+    "transitAdAccessibilityHint": "打开广告商链接",
     "advertisingOpportunity": "广告机会",
     "advertisingOpportunityDescription": "为圣米格尔巴士的居民和游客宣传您的业务。",
     "exactTargeting": "精准定位",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the Expo client half of `docs/plans/2026-06-04-003-feat-transit-ads-premium-gating-plan.md` (U2–U7). Backend U1 is in the companion API PR.

Ships first-party SMB ad banners (compat `GET /api/v1/ad`) on the transit search and directions surfaces for free users only, and re-gates bus tracking + pinned routes behind premium with upsell-on-tap. No interstitials, no in-banner subscribe CTAs.

## Changes

- **U2 — ad API client** (`lib/api.ts`, `lib/types.ts`): `fetchAd` (404 → `null`, never throws) and fire-and-forget `recordAdClick`; `AdPayload` type mirrors compat snake_case.
- **U3 — `AdBanner` + `useAd`** (`features/ads/*`): image + link only, no dismiss/CTA. Hook is disabled (no fetch) for premium and offline; per-slot query keys for rotation. `lib/consent-store.ts` adds `canShowFirstPartyAds()` (true for non-premium) and documents that `purposes.ads` is reserved for future third-party SDKs (`canShowExternalAds()`) — first-party banners are **not** consent-gated (R5/KTD7).
- **U4 — search wiring** (`app/(tabs)/transit/index.tsx`, `RouteResults.tsx`): top banner above results, inline banner after every 2 result cards; top banner refetches on new search.
- **U5 — premium gate** (`features/premium/hooks/usePremiumGate.ts`, `TrackButton.tsx`, `ActiveTrackingSection.tsx`, `PinnedRoutesSection.tsx`): `guardPremiumAction` — premium runs; signed-out → sign-in then paywall resume; signed-in free → `presentIfNeeded()`. Track/pin buttons stay visible; stopping a track is never gated. Active/Pinned sections render only for premium.
- **U6 — directions inline ads** (`DirectionsResults.tsx`): inline `on="routes"` every 2 routes.
- **U7 — i18n + analytics**: `transitAdLabel` / `transitAdAccessibilityHint` in all 8 locales; `track('transit', 'ad_impression' | 'ad_click', …)`, consent-gated by the existing `track()` helper.

## Tests

- ✅ `npx tsc --noEmit` (clean)
- ✅ locale JSON parse check (all 8 valid)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ccd7069-383e-43f4-9193-b2b69ae5cbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ccd7069-383e-43f4-9193-b2b69ae5cbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

